### PR TITLE
Run tests with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,11 @@
 language: rust
+before_install:
+  - sudo apt-get update -qq
+install:
+  - sudo apt-get install -y libsdl1.2debian
+  - curl -L "http://doryen.eptalys.net/?file_id=28" -o libtcod-1.5.1-linux64.tar.gz
+  - tar -xzf libtcod-1.5.1-linux64.tar.gz
+  - sudo cp libtcod-1.5.1/libtcod{,gui}.so /usr/lib/x86_64-linux-gnu/
 script:
   - cargo build --verbose
+  - cargo test --verbose


### PR DESCRIPTION
Because `cargo test` builds the examples as well, Rust needs to be able
to link against libtcod.so.

Since it's not packaged in Ubuntu (which is what our Travis tests run
on), we download the release binaries from the official website and copy
them to where all the other system libraries are.
