### PR TITLE
Add 'static bounds to path finding closures

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,9 +319,9 @@ extern "C" fn c_path_callback(xf: c_int, yf: c_int,
 }
 
 impl AStarPath {
-    pub fn new_from_callback<T: FnMut(from: (int, int), to: (int, int)) -> f32>(width: int, height: int,
-                                                                                path_callback: T,
-                                                                                diagonal_cost: f32) -> AStarPath {
+    pub fn new_from_callback<T: 'static+FnMut(from: (int, int), to: (int, int)) -> f32>(
+        width: int, height: int, path_callback: T,
+        diagonal_cost: f32) -> AStarPath {
         // Convert the closure to a trait object. This will turn it into a fat pointer:
         let user_closure: Box<FnMut<((int, int), (int, int)), f32>> = box path_callback;
         unsafe {
@@ -464,9 +464,10 @@ pub struct DijkstraPath {
 }
 
 impl DijkstraPath {
-    pub fn new_from_callback<T: FnMut((int, int), (int, int)) -> f32>(width: int, height: int,
-                                                                      path_callback: T,
-                                                                      diagonal_cost: f32) -> DijkstraPath {
+    pub fn new_from_callback<T: 'static+FnMut((int, int), (int, int)) -> f32>(
+        width: int, height: int,
+        path_callback: T,
+        diagonal_cost: f32) -> DijkstraPath {
         // NOTE: this is might be a bit confusing. See the
         // AStarPath::new_from_callback implementation comments.
         let user_closure: Box<FnMut<((int, int), (int, int)), f32>> = box path_callback;


### PR DESCRIPTION
rustc 0.13.0-nightly (c46812f65 2014-10-19 00:47:18 +0000) was failing when they
weren't there.
