### PR TITLE
Fix failing CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ before_install:
   - sudo apt-get update -qq
 install:
   - sudo apt-get install -y libsdl1.2debian
-  - curl -L "http://doryen.eptalys.net/?file_id=28" -o libtcod-1.5.1-linux64.tar.gz
+  - curl -L "http://roguecentral.org/doryen/?file_id=28" -o libtcod-1.5.1-linux64.tar.gz
   - tar -xzf libtcod-1.5.1-linux64.tar.gz
   - sudo cp libtcod-1.5.1/libtcod{,gui}.so /usr/lib/x86_64-linux-gnu/
 script:


### PR DESCRIPTION
The URL for the libtcod release download has changed, the tcod site now lives
at: http://roguecentral.org/doryen/
