### PR TITLE
Add lifetime bounds to the path-finding structs

### DIFF
--- a/examples/astar-path-finding.rs
+++ b/examples/astar-path-finding.rs
@@ -4,7 +4,7 @@ extern crate tcod;
 
 use tcod::AStarPath;
 
-fn create_path() -> AStarPath {
+fn create_path() -> AStarPath<'static> {
     let chess_board: [[int, ..8], ..8] = [
         [1, 0, 1, 0, 1, 0, 1, 0],
         [0, 1, 0, 1, 0, 1, 0, 1],

--- a/examples/dijkstra-path-finding.rs
+++ b/examples/dijkstra-path-finding.rs
@@ -4,7 +4,7 @@ extern crate tcod;
 
 use tcod::DijkstraPath;
 
-fn create_path() -> DijkstraPath {
+fn create_path() -> DijkstraPath<'static> {
     let chess_board: [[int, ..8], ..8] = [
         [1, 0, 1, 0, 1, 0, 1, 0],
         [0, 1, 0, 1, 0, 1, 0, 1],


### PR DESCRIPTION
The caller can still specify the `'static` bound if they wish the closure to
escape the stack frame, but this lets us use the by-ref closures as well.
