### PR TITLE
Added set_window_title() and made set_custom_font() more flexible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,7 @@ impl Console {
         }
     }
 
-    pub fn set_custom_font(font_path: ::std::path::Path, flags: Vec<FontFlags>,
+    pub fn set_custom_font(font_path: ::std::path::Path, flags: &[FontFlags],
                            nb_char_horizontal: int,
                            nb_char_vertical: int) {
         unsafe {


### PR DESCRIPTION
Hello,

Here are two changes I needed so far. I'm not sure the `set_custom_font()` one is very idiomatic, it seems a bit overkill to create a vector to pass a combination of enum values.
