### PR TITLE
Handle TCODK_NONE in wait_for_keypress correctly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,7 +186,6 @@ impl Console {
         let tcod_key = unsafe {
             ffi::TCOD_console_wait_for_keypress(flush as c_bool)
         };
-        assert!(tcod_key.vk != ffi::TCODK_NONE);
         let key = if tcod_key.vk == ffi::TCODK_CHAR {
             Printable(tcod_key.c as u8 as char)
         } else {


### PR DESCRIPTION
Closing the window while waiting for a keypress will cause libtcod to return a
key type of `TCODK_NONE`.

This should be handled correctly instead of panicking. I don't even know why the
assert was there in the first place.

Fixes #28
