### PR TITLE
Update to Rust master

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,11 @@ build = "./build.sh"
 
 name = "tcod"
 path = "src/lib.rs"
+
+
+# TODO: temporarily disabling debuginfo until this is fixed:
+# https://github.com/rust-lang/rust/issues/17257
+[profile.dev]
+debug = false
+[profile.test]
+debug = false


### PR DESCRIPTION
Test are broken with a regression that crashes the compiler on an
unboxed closure which captures some environment:

https://github.com/rust-lang/rust/issues/17257

As this only happens with debuginfo on, this temporarily disables it for
dev & test. This should make Travis happy again.
