### PR TITLE
Update to rust master

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -662,8 +662,6 @@ bitflags! {
     }
 }
 
-impl Copy for FontFlags {}
-
 
 #[deriving(Copy, PartialEq, FromPrimitive, Show)]
 #[repr(C)]
@@ -1033,5 +1031,3 @@ bitflags! {
         const KEY_RELEASED = ffi::TCOD_KEY_RELEASED,
     }
 }
-
-impl Copy for KeyPressFlags {}


### PR DESCRIPTION
The `bitflags` macro didn't initially add a Copy impl so we had to do
that manually. Now it does and it was conflicting with the our explicit
implementation.
