### PR TITLE
Added mouse support (mouse_show_cursor(), mouse_is_cursor_visible(), mouse_move() and sys_check_for_event())

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,23 @@ pub use ffi::TCOD_color_t as Color;
 #[allow(non_camel_case_types)]
 type c_bool = uint8_t;
 
+pub fn mouse_show_cursor(visible: bool) {
+    unsafe {
+        ffi::TCOD_mouse_show_cursor(visible as c_bool);
+    }
+}
+
+pub fn mouse_is_cursor_visible() -> bool {
+    unsafe {
+        ffi::TCOD_mouse_is_cursor_visible() != 0
+    }
+}
+
+pub fn mouse_move(x: int, y: int) {
+    unsafe {
+        ffi::TCOD_mouse_move(x as c_int, y as c_int);
+    }
+}
 
 // Private wrapper over TCOD_console_t. Ideally, we'd have it as a private field
 // in OffscreenConsole, but that doesn't seem to be possible now.


### PR DESCRIPTION
I'm not sure what's the convention for porting names from the C API to Rust, so I pretty much kept them the same.

`sys_check_for_event()` is a bit messy internally, I think it should delegate much of its behavior to `KeyState` and `MouseState`.
I'm not too happy about the way it's used currently either. It doesn't feel like you're using a high level langage and requires to setup one or two mutable variables. I wasn't sure what to do so this is a direct port from the C API.
Here is an example of how I use it currently:

    let mut mouse_state = tcod::MouseState::new();
    let mut key_state = tcod::KeyState::new();

    loop {
        let event = tcod::sys_check_for_event(
            tcod::KEY | tcod::MOUSE,
            Option::Some(&mut key_state),
            Option::Some(&mut mouse_state));

        if !(event & tcod::KEY).is_empty() {
            println!("{}", key_state);
        } else if !(event & tcod::MOUSE).is_empty() {
            println!("{}", mouse_state);
        }

        if event == tcod::ANY {
            break;
        }
    }