### PR TITLE
Mouse support improvements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,107 +30,6 @@ pub fn mouse_move(x: i32, y: i32) {
     }
 }
 
-pub fn sys_check_for_event(event_mask: EventFlags) -> (EventFlags, Event) {
-    let mut c_key_state = ffi::TCOD_key_t {
-        vk: 0,
-        c: ' ' as libc::c_char,
-        pressed: false as c_bool,
-        lalt: false as c_bool,
-        lctrl: false as c_bool,
-        ralt: false as c_bool,
-        rctrl: false as c_bool,
-        shift: false as c_bool
-    };
-
-    let mut c_mouse_state = ffi::TCOD_mouse_t {
-        x: 0,
-        y: 0,
-        dx: 0,
-        dy: 0,
-        cx: 0,
-        cy: 0,
-        dcx: 0,
-        dcy: 0,
-        lbutton: false as c_bool,
-        rbutton: false as c_bool,
-        mbutton: false as c_bool,
-        lbutton_pressed: false as c_bool,
-        rbutton_pressed: false as c_bool,
-        mbutton_pressed: false as c_bool,
-        wheel_up: false as c_bool,
-        wheel_down: false as c_bool
-    };
-
-    let event = unsafe {
-        ffi::TCOD_sys_check_for_event(
-            event_mask.bits() as i32,
-            if event_mask.intersects(KEY_PRESS|KEY_RELEASE|KEY|ANY) {
-                &mut c_key_state
-            } else {
-                std::ptr::null_mut()
-            },
-            if event_mask.intersects(
-                MOUSE_MOVE|MOUSE_PRESS|MOUSE_RELEASE|MOUSE|ANY) {
-                &mut c_mouse_state
-            } else {
-                std::ptr::null_mut()
-            })
-    };
-
-    let ret_flag = match event {
-        ffi::TCOD_EVENT_KEY_PRESS => KEY_PRESS,
-        ffi::TCOD_EVENT_KEY_RELEASE => KEY_RELEASE,
-        ffi::TCOD_EVENT_KEY => KEY,
-        ffi::TCOD_EVENT_MOUSE => MOUSE,
-        ffi::TCOD_EVENT_MOUSE_MOVE => MOUSE_MOVE,
-        ffi::TCOD_EVENT_MOUSE_PRESS => MOUSE_PRESS,
-        ffi::TCOD_EVENT_MOUSE_RELEASE => MOUSE_RELEASE,
-        _ => ANY
-    };
-
-    let ret_event = if ret_flag == ANY {
-        Event::None
-    } else if ret_flag.intersects(KEY_PRESS|KEY_RELEASE|KEY) {
-        Event::Key(KeyState {
-            key: if c_key_state.vk == ffi::TCODK_CHAR {
-                Key::Printable(c_key_state.c as u8 as char)
-            } else {
-                Key::Special(FromPrimitive::from_u32(c_key_state.vk)
-                             .unwrap())
-            },
-            pressed: c_key_state.pressed != 0,
-            left_alt: c_key_state.lalt != 0,
-            left_ctrl: c_key_state.lctrl != 0,
-            right_alt: c_key_state.ralt != 0,
-            right_ctrl: c_key_state.rctrl != 0,
-            shift: c_key_state.shift != 0
-        })
-    } else if ret_flag.intersects(MOUSE_MOVE|MOUSE_PRESS|MOUSE_RELEASE|MOUSE) {
-        Event::Mouse(MouseState {
-            x: c_mouse_state.x as isize,
-            y: c_mouse_state.y as isize,
-            dx: c_mouse_state.dx as isize,
-            dy: c_mouse_state.dy as isize,
-            cx: c_mouse_state.cx as isize,
-            cy: c_mouse_state.cy as isize,
-            dcx: c_mouse_state.dcx as isize,
-            dcy: c_mouse_state.dcy as isize,
-            lbutton: c_mouse_state.lbutton != 0,
-            rbutton: c_mouse_state.rbutton != 0,
-            mbutton: c_mouse_state.mbutton != 0,
-            lbutton_pressed: c_mouse_state.lbutton_pressed != 0,
-            rbutton_pressed: c_mouse_state.rbutton_pressed != 0,
-            mbutton_pressed: c_mouse_state.mbutton_pressed != 0,
-            wheel_up: c_mouse_state.wheel_up != 0,
-            wheel_down: c_mouse_state.wheel_down != 0
-        })
-    } else {
-        Event::None
-    };
-
-    (ret_flag, ret_event)
-}
-
 // Private wrapper over TCOD_console_t. Ideally, we'd have it as a private field
 // in OffscreenConsole, but that doesn't seem to be possible now.
 pub struct LibtcodConsole {
@@ -1123,14 +1022,16 @@ pub enum BackgroundFlag {
     Default = ffi::TCOD_BKGND_DEFAULT as isize
 }
 
-pub enum Event {
-    Key(KeyState),
-    Mouse(MouseState),
-    None
-}
-
 pub mod system {
+    use std;
+    use std::num::FromPrimitive;
     use ffi;
+    use libc::{c_int, c_uint, c_float, uint8_t, c_void, c_char};
+    use ::{c_bool,
+           Key, EventFlags,
+           ANY,
+           KEY, KEY_RELEASE, KEY_PRESS,
+           MOUSE, MOUSE_RELEASE, MOUSE_PRESS, MOUSE_MOVE};
 
     pub fn set_fps(fps: i32) {
         assert!(fps > 0);
@@ -1152,6 +1053,113 @@ pub mod system {
         unsafe {
             ffi::TCOD_sys_get_last_frame_length() as f32
         }
+    }
+
+    pub fn check_for_event(event_mask: EventFlags) -> (EventFlags, Event) {
+        let mut c_key_state = ffi::TCOD_key_t {
+            vk: 0,
+            c: ' ' as c_char,
+            pressed: false as c_bool,
+            lalt: false as c_bool,
+            lctrl: false as c_bool,
+            ralt: false as c_bool,
+            rctrl: false as c_bool,
+            shift: false as c_bool
+        };
+
+        let mut c_mouse_state = ffi::TCOD_mouse_t {
+            x: 0,
+            y: 0,
+            dx: 0,
+            dy: 0,
+            cx: 0,
+            cy: 0,
+            dcx: 0,
+            dcy: 0,
+            lbutton: false as c_bool,
+            rbutton: false as c_bool,
+            mbutton: false as c_bool,
+            lbutton_pressed: false as c_bool,
+            rbutton_pressed: false as c_bool,
+            mbutton_pressed: false as c_bool,
+            wheel_up: false as c_bool,
+            wheel_down: false as c_bool
+        };
+
+        let event = unsafe {
+            ffi::TCOD_sys_check_for_event(
+                event_mask.bits() as i32,
+                if event_mask.intersects(KEY_PRESS|KEY_RELEASE|KEY|ANY) {
+                    &mut c_key_state
+                } else {
+                    std::ptr::null_mut()
+                },
+                if event_mask.intersects(
+                    MOUSE_MOVE|MOUSE_PRESS|MOUSE_RELEASE|MOUSE|ANY) {
+                    &mut c_mouse_state
+                } else {
+                    std::ptr::null_mut()
+                })
+        };
+
+        let ret_flag = match event {
+            ffi::TCOD_EVENT_KEY_PRESS => KEY_PRESS,
+            ffi::TCOD_EVENT_KEY_RELEASE => KEY_RELEASE,
+            ffi::TCOD_EVENT_KEY => KEY,
+            ffi::TCOD_EVENT_MOUSE => MOUSE,
+            ffi::TCOD_EVENT_MOUSE_MOVE => MOUSE_MOVE,
+            ffi::TCOD_EVENT_MOUSE_PRESS => MOUSE_PRESS,
+            ffi::TCOD_EVENT_MOUSE_RELEASE => MOUSE_RELEASE,
+            _ => ANY
+        };
+
+        let ret_event = if ret_flag == ANY {
+            Event::None
+        } else if ret_flag.intersects(KEY_PRESS|KEY_RELEASE|KEY) {
+            Event::Key(::KeyState {
+                key: if c_key_state.vk == ffi::TCODK_CHAR {
+                    Key::Printable(c_key_state.c as u8 as char)
+                } else {
+                    Key::Special(FromPrimitive::from_u32(c_key_state.vk)
+                                 .unwrap())
+                },
+                pressed: c_key_state.pressed != 0,
+                left_alt: c_key_state.lalt != 0,
+                left_ctrl: c_key_state.lctrl != 0,
+                right_alt: c_key_state.ralt != 0,
+                right_ctrl: c_key_state.rctrl != 0,
+                shift: c_key_state.shift != 0
+            })
+        } else if ret_flag.intersects(MOUSE_MOVE|MOUSE_PRESS|MOUSE_RELEASE|MOUSE) {
+            Event::Mouse(::MouseState {
+                x: c_mouse_state.x as isize,
+                y: c_mouse_state.y as isize,
+                dx: c_mouse_state.dx as isize,
+                dy: c_mouse_state.dy as isize,
+                cx: c_mouse_state.cx as isize,
+                cy: c_mouse_state.cy as isize,
+                dcx: c_mouse_state.dcx as isize,
+                dcy: c_mouse_state.dcy as isize,
+                lbutton: c_mouse_state.lbutton != 0,
+                rbutton: c_mouse_state.rbutton != 0,
+                mbutton: c_mouse_state.mbutton != 0,
+                lbutton_pressed: c_mouse_state.lbutton_pressed != 0,
+                rbutton_pressed: c_mouse_state.rbutton_pressed != 0,
+                mbutton_pressed: c_mouse_state.mbutton_pressed != 0,
+                wheel_up: c_mouse_state.wheel_up != 0,
+                wheel_down: c_mouse_state.wheel_down != 0
+            })
+        } else {
+            Event::None
+        };
+
+        (ret_flag, ret_event)
+    }
+
+    pub enum Event {
+        Key(::KeyState),
+        Mouse(::MouseState),
+        None
     }
 }
 


### PR DESCRIPTION
First batch of mouse improvements.

* `sys_check_for_event()` now returns `(EventFlags, Event)` where `Event` is:

        enum Event {
            Key(KeyState),
            Mouse(MouseState),
            None
        }

*  `sys_check_for_event()` moved to  `system::check_for_event()` (I also put `Event` in `system`, feel free to chang this).

While writing this, I was wondering if `mouse_*` functions should be moved to a `mouse` module?

Usage example:

    loop {
        let (flags, event) = tcod::system::check_for_event(
                tcod::KEY | tcod::MOUSE);

        match event {
            tcod::system::Event::Key(ref key_state) => {
                // ...
            },
            tcod::system::Event::Mouse(ref mouse_state) => {
                // ...
            }
            tcod::system::Event::None => {
                break;
            }
        }
    }