### PR TITLE
Moved mouse specific functions to a new mouse module.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,24 +12,6 @@ use std::ffi::CString;
 #[allow(non_camel_case_types)]
 type c_bool = uint8_t;
 
-pub fn mouse_show_cursor(visible: bool) {
-    unsafe {
-        ffi::TCOD_mouse_show_cursor(visible as c_bool);
-    }
-}
-
-pub fn mouse_is_cursor_visible() -> bool {
-    unsafe {
-        ffi::TCOD_mouse_is_cursor_visible() != 0
-    }
-}
-
-pub fn mouse_move(x: i32, y: i32) {
-    unsafe {
-        ffi::TCOD_mouse_move(x, y);
-    }
-}
-
 // Private wrapper over TCOD_console_t. Ideally, we'd have it as a private field
 // in OffscreenConsole, but that doesn't seem to be possible now.
 pub struct LibtcodConsole {
@@ -1163,6 +1145,28 @@ pub mod system {
     }
 }
 
+pub mod mouse {
+    use ffi;
+    use ::c_bool;
+
+    pub fn show_cursor(visible: bool) {
+        unsafe {
+            ffi::TCOD_mouse_show_cursor(visible as c_bool);
+        }
+    }
+
+    pub fn is_cursor_visible() -> bool {
+        unsafe {
+            ffi::TCOD_mouse_is_cursor_visible() != 0
+        }
+    }
+
+    pub fn move_cursor(x: i32, y: i32) {
+        unsafe {
+            ffi::TCOD_mouse_move(x, y);
+        }
+    }
+}
 
 bitflags! {
     flags KeyPressFlags: c_uint {


### PR DESCRIPTION
move() was renamed to move_cursor() since move is a reserved keyword.