### PR TITLE
Update to work with the latest version of Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ authors = ["Tomas Sedovic <tomas@sedovic.cz>",
 name = "tcod"
 path = "src/lib.rs"
 
+[dependencies]
+bitflags = "0.1"
+
 [dependencies.tcod-sys]
 path = "tcod-sys"
 version = "2.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 extern crate libc;
 extern crate "tcod-sys" as ffi;
+#[macro_use] extern crate bitflags;
 
 use libc::{c_int, c_uint, c_float, uint8_t, c_void};
 


### PR DESCRIPTION
The bitflags! macro was moved out of Rust and onto crates.io, so this adds it as a dependency.