### PR TITLE
Silence the new warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(unstable)]
+#![feature(libc, std_misc, path, core, hash, io, collections)]
 
 extern crate libc;
 extern crate "tcod-sys" as ffi;

--- a/tcod-sys/build.rs
+++ b/tcod-sys/build.rs
@@ -1,5 +1,5 @@
 // TODO(shadower): remove this once the dust settles around path and IO:
-#![allow(unstable)]
+#![feature(os, path, io)]
 
 use std::old_io::{fs, Command};
 use std::os;

--- a/tcod-sys/lib.rs
+++ b/tcod-sys/lib.rs
@@ -1,8 +1,6 @@
 #![allow(non_camel_case_types, non_snake_case, non_upper_case_globals,
          missing_copy_implementations, raw_pointer_derive)]
-
-
-#[allow(unstable)]
+#![feature(libc, core)]
 // This is not added by rust-bindgen even though it's used heavily in the
 // generated code:
 extern crate libc;


### PR DESCRIPTION
`unstable` lint was replaced with a more fine-grained feature opt-in system.
Let's just opt in to everything we use for now.