### PR TITLE
Revert "Test on both Linux and OSX"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: rust
 
-os:
-  - linux
-  - osx
-
 before_install:
   - sudo apt-get update -qq
 


### PR DESCRIPTION
Reverts tomassedovic/tcod-rs#98 since the build script is not prepared to test on OSX (for example, we cannot use `apt-get` on OSX to get dependencies).