### PR TITLE
Update to latest Rust

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(libc, std_misc, old_path, core, hash, old_io)]
+#![feature(libc, std_misc, old_path, core, old_io)]
 
 extern crate libc;
 extern crate "tcod-sys" as ffi;
@@ -58,10 +58,11 @@ impl Console {
     pub fn init_root(width: i32, height: i32, title: &str, fullscreen: bool) -> Console {
         assert!(width > 0 && height > 0);
         unsafe {
-            let c_title = CString::from_slice(title.as_bytes());
+            let c_title = CString::new(title.as_bytes()).unwrap();
             ffi::TCOD_console_init_root(width, height,
-                                            c_title.as_ptr(), fullscreen as c_bool,
-                                            ffi::TCOD_RENDERER_SDL);
+                                        c_title.as_ptr(),
+                                        fullscreen as c_bool,
+                                        ffi::TCOD_RENDERER_SDL);
         }
         Console::Root
     }
@@ -170,7 +171,7 @@ impl Console {
                     text: &str) {
         assert!(x >= 0 && y >= 0);
         unsafe {
-            let c_text = CString::from_slice(text.as_bytes());
+            let c_text = CString::new(text.as_bytes()).unwrap();
             ffi::TCOD_console_print_ex(self.con(),
                                         x, y,
                                         background_flag as u32,
@@ -189,7 +190,7 @@ impl Console {
                            nb_char_horizontal: i32,
                            nb_char_vertical: i32) {
         unsafe {
-            let path = CString::from_slice(font_path.as_vec());
+            let path = CString::new(font_path.as_vec()).unwrap();
             ffi::TCOD_console_set_custom_font(
                 path.as_ptr(), flags.bits() as i32, nb_char_horizontal,
                 nb_char_vertical);
@@ -253,7 +254,7 @@ impl Console {
 
     pub fn set_window_title(title: &str) {
         unsafe {
-            let c_title = CString::from_slice(title.as_bytes());
+            let c_title = CString::new(title.as_bytes()).unwrap();
             ffi::TCOD_console_set_window_title(c_title.as_ptr());
         }
     }
@@ -1092,7 +1093,7 @@ pub mod system {
 
     pub fn save_screenshot(path: &std::old_path::Path) {
         assert!(path.exists());
-        let c_path = std::ffi::CString::from_slice(path.as_vec());
+        let c_path = std::ffi::CString::new(path.as_vec()).unwrap();
         unsafe {
             ffi::TCOD_sys_save_screenshot(c_path.as_ptr());
         }
@@ -1139,7 +1140,7 @@ pub mod system {
     }
 
     pub fn set_clipboard(value: &str) {
-        let c_str = std::ffi::CString::from_slice(value.as_bytes());
+        let c_str = std::ffi::CString::new(value.as_bytes()).unwrap();
         unsafe {
             ffi::TCOD_sys_clipboard_set(c_str.as_ptr());
         }
@@ -1148,7 +1149,7 @@ pub mod system {
     pub fn get_clipboard() -> String {
         unsafe {
             let c_ptr = ffi::TCOD_sys_clipboard_get();
-            let c_str = std::ffi::c_str_to_bytes(&c_ptr);
+            let c_str = std::ffi::CStr::from_ptr(c_ptr).to_bytes();
             std::str::from_utf8(c_str).unwrap().to_string()
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,11 +420,11 @@ impl<'a> AStarPath<'a> {
         }
     }
 
-    pub fn walk<'b>(&'b mut self) -> AStarPathIterator<'b> {
+    pub fn walk(&mut self) -> AStarPathIterator {
         AStarPathIterator{tcod_path: self.tcod_path.ptr, recalculate: false}
     }
 
-    pub fn walk_recalculate<'b>(&'b mut self) -> AStarPathIterator<'b> {
+    pub fn walk_recalculate(&mut self) -> AStarPathIterator {
         AStarPathIterator{tcod_path: self.tcod_path.ptr, recalculate: true}
     }
 
@@ -567,7 +567,7 @@ impl<'a> DijkstraPath<'a> {
         }
     }
 
-    pub fn walk<'b>(&'b mut self) -> DijkstraPathIterator<'b> {
+    pub fn walk(&mut self) -> DijkstraPathIterator {
         DijkstraPathIterator{tcod_path: self.tcod_path.ptr}
     }
 
@@ -626,12 +626,12 @@ impl<'a> DijkstraPath<'a> {
     }
 }
 
-pub struct AStarPathIterator<'a> {
+pub struct AStarPathIterator {
     tcod_path: ffi::TCOD_path_t,
     recalculate: bool,
 }
 
-impl<'a> Iterator for AStarPathIterator<'a> {
+impl Iterator for AStarPathIterator {
     type Item = (isize, isize);
 
     fn next(&mut self) -> Option<(isize, isize)> {
@@ -647,11 +647,11 @@ impl<'a> Iterator for AStarPathIterator<'a> {
     }
 }
 
-pub struct DijkstraPathIterator<'a> {
+pub struct DijkstraPathIterator {
     tcod_path: ffi::TCOD_path_t,
 }
 
-impl<'a> Iterator for DijkstraPathIterator<'a> {
+impl Iterator for DijkstraPathIterator {
     type Item = (isize, isize);
 
     fn next(&mut self) -> Option<(isize, isize)> {

--- a/tcod-sys/build.rs
+++ b/tcod-sys/build.rs
@@ -33,8 +33,8 @@ fn main() {
             if output.status.success() {
                 println!("`make` succeeded.");
             } else {
-                println!("STDOUT: {}", String::from_utf8_lossy(&output.output[]));
-                println!("STDERR: {}", String::from_utf8_lossy(&output.error[]));
+                println!("STDOUT: {}", String::from_utf8_lossy(&output.output));
+                println!("STDERR: {}", String::from_utf8_lossy(&output.error));
                 panic!("`make` returned: {}", output.status);
             }
         }

--- a/tcod-sys/lib.rs
+++ b/tcod-sys/lib.rs
@@ -10,7 +10,7 @@ extern crate libc;
 
 pub type __int128_t = ::libc::c_void;
 pub type __uint128_t = ::libc::c_void;
-pub type __builtin_va_list = [__va_list_tag; 1us];
+pub type __builtin_va_list = [__va_list_tag; 1usize];
 pub enum Struct__IO_FILE { }
 pub type FILE = Struct__IO_FILE;
 pub type __FILE = Struct__IO_FILE;
@@ -30,13 +30,13 @@ impl ::std::default::Default for Struct_Unnamed1 {
 #[repr(C)]
 #[derive(Copy)]
 pub struct Union_Unnamed2 {
-    pub _bindgen_data_: [u32; 1us],
+    pub _bindgen_data_: [u32; 1usize],
 }
 impl Union_Unnamed2 {
     pub unsafe fn __wch(&mut self) -> *mut ::libc::c_uint {
         ::std::mem::transmute(&self._bindgen_data_)
     }
-    pub unsafe fn __wchb(&mut self) -> *mut [::libc::c_char; 4us] {
+    pub unsafe fn __wchb(&mut self) -> *mut [::libc::c_char; 4usize] {
         ::std::mem::transmute(&self._bindgen_data_)
     }
 }
@@ -50,11 +50,11 @@ pub enum Struct___locale_data { }
 #[repr(C)]
 #[derive(Copy)]
 pub struct Struct___locale_struct {
-    pub __locales: [*mut Struct___locale_data; 13us],
+    pub __locales: [*mut Struct___locale_data; 13usize],
     pub __ctype_b: *const ::libc::c_ushort,
     pub __ctype_tolower: *const ::libc::c_int,
     pub __ctype_toupper: *const ::libc::c_int,
-    pub __names: [*const ::libc::c_char; 13us],
+    pub __names: [*const ::libc::c_char; 13usize],
 }
 impl ::std::default::Default for Struct___locale_struct {
     fn default() -> Struct___locale_struct { unsafe { ::std::mem::zeroed() } }
@@ -472,8 +472,8 @@ pub struct Struct_Unnamed23 {
     pub nb_symbols: ::libc::c_int,
     pub nb_keywords: ::libc::c_int,
     pub flags: ::libc::c_int,
-    pub symbols: [[::libc::c_char; 5us]; 100us],
-    pub keywords: [[::libc::c_char; 20us]; 100us],
+    pub symbols: [[::libc::c_char; 5usize]; 100usize],
+    pub keywords: [[::libc::c_char; 20usize]; 100usize],
     pub simpleCmt: *const ::libc::c_char,
     pub cmtStart: *const ::libc::c_char,
     pub cmtStop: *const ::libc::c_char,
@@ -533,7 +533,7 @@ pub type TCOD_value_type_t = Enum_Unnamed24;
 #[repr(C)]
 #[derive(Copy)]
 pub struct Union_Unnamed25 {
-    pub _bindgen_data_: [u64; 2us],
+    pub _bindgen_data_: [u64; 2usize],
 }
 impl Union_Unnamed25 {
     pub unsafe fn b(&mut self) -> *mut _bool {
@@ -621,7 +621,7 @@ pub type TCOD_struct_int_t = Struct_Unnamed27;
 #[derive(Copy)]
 pub struct Struct_Unnamed28 {
     pub structs: TCOD_list_t,
-    pub customs: [TCOD_parser_custom_t; 16us],
+    pub customs: [TCOD_parser_custom_t; 16usize],
     pub fatal: _bool,
     pub props: TCOD_list_t,
 }
@@ -688,7 +688,7 @@ impl ::std::default::Default for Struct___va_list_tag {
 }
 #[link(name = "tcod")]
 extern "C" {
-    pub static mut TCOD_colors: [[TCOD_color_t; 8us]; 21us];
+    pub static mut TCOD_colors: [[TCOD_color_t; 8usize]; 21usize];
     pub static TCOD_black: TCOD_color_t;
     pub static TCOD_darkest_grey: TCOD_color_t;
     pub static TCOD_darker_grey: TCOD_color_t;


### PR DESCRIPTION
This fixes a handful of warnings and errors on the latest Rust:

    rustc 1.0.0-nightly (522d09dfe 2015-02-19) (built 2015-02-20)