### PR TITLE
Add the debug symbols back for debug/test builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,3 @@ version = "2.0.5"
 
 [dev-dependencies]
 rand = "0.1.2"
-
-# TODO: temporarily disabling debuginfo until this is fixed:
-# https://github.com/rust-lang/rust/issues/17257
-[profile.dev]
-debug = false
-[profile.test]
-debug = false


### PR DESCRIPTION
The referenced issue isn't closed, but we're no longer getting build
errors so let's do this.