### PR TITLE
Added iterator version of tcod::system::check_for_event()

### DIFF
--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -11,20 +11,21 @@ fn main() {
     while !Console::window_closed() {
 
         loop {
-            let (_flags, event) = tcod::system::check_for_event(
-                tcod::KEY | tcod::MOUSE);
-
-            match event {
-                tcod::system::Event::Key(ref key_state) => {
-                    println!("{:?}", key_state);
-                },
-                tcod::system::Event::Mouse(ref mouse_state) => {
-                    x = mouse_state.cx as i32;
-                    y = mouse_state.cy as i32;
-                    println!("{:?}", mouse_state);
-                }
-                tcod::system::Event::None => {
+            match tcod::system::check_for_event(tcod::KEY | tcod::MOUSE) {
+                None => {
                     break;
+                }
+                Some((flags, event)) => {
+                    match event {
+                        tcod::system::Event::Key(ref key_state) => {
+                            println!("{:?}", key_state);
+                        },
+                        tcod::system::Event::Mouse(ref mouse_state) => {
+                            x = mouse_state.cx as i32;
+                            y = mouse_state.cy as i32;
+                            println!("{:?}", mouse_state);
+                        }
+                    }
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1492,11 +1492,49 @@ pub mod system {
         (ret_flag, ret_event)
     }
 
+    pub fn check_for_event_iter() -> EventIterator {
+        EventIterator::new()
+    }
+
     #[derive(Copy, Debug)]
     pub enum Event {
         Key(::KeyState),
         Mouse(::MouseState),
         None
+    }
+
+    #[derive(Copy, Debug)]
+    pub enum IteratedEvent {
+        Key(::KeyState),
+        Mouse(::MouseState)
+    }
+
+    pub struct EventIterator;
+
+    impl EventIterator {
+        pub fn new() -> Self {
+            EventIterator
+        }
+    }
+
+    impl Iterator for EventIterator {
+        type Item = (EventFlags, IteratedEvent);
+
+        fn next(&mut self) -> Option<(EventFlags, IteratedEvent)> {
+            let (flags, event) = check_for_event(KEY | MOUSE);
+
+            match event {
+                Event::None => {
+                    None
+                },
+                Event::Key(ref key_state) => {
+                    Some((flags, IteratedEvent::Key(*key_state)))
+                },
+                Event::Mouse(ref mouse_state) => {
+                    Some((flags, IteratedEvent::Mouse(*mouse_state)))
+                }
+            }
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1492,7 +1492,7 @@ pub mod system {
         (ret_flag, ret_event)
     }
 
-    pub fn check_for_event_iter() -> EventIterator {
+    pub fn events() -> EventIterator {
         EventIterator::new()
     }
 


### PR DESCRIPTION
It's used like this:

```
for (flags, event) in tcod::system::check_for_event_iter() {
    match event {
        IteratedEvent::Key(ref key_state) => {
            // ...
        },
        IteratedEvent::Mouse(ref mouse_state) => {
            // ...
        }
    }
}
```