### PR TITLE
Switch to the new syntax for linking in tcod_sys build script

### DIFF
--- a/tcod_sys/build.rs
+++ b/tcod_sys/build.rs
@@ -62,5 +62,5 @@ fn main() {
 
     // TODO: can we (optionally?) produce a static copy? It'd probably be more
     // work, but would be easier for the end users.
-    println!("cargo:rustc-flags=-l tcod:dylib -L {}", dst.display())
+    println!("cargo:rustc-flags=-l dylib=tcod -L {}", dst.display())
 }


### PR DESCRIPTION
This fixes the current issue with `cargo test`.