### PR TITLE
Console API rework

### DIFF
--- a/examples/blit.rs
+++ b/examples/blit.rs
@@ -34,6 +34,6 @@ fn main() {
     console::blit(&trait_object, 0, 0, 20, 20, &mut root, 0, 20, 1.0, 1.0); 
     console::blit(&boxed_trait, 0, 0, 20, 20, &mut root, 20, 20, 1.0, 1.0); 
 
-    RootConsole::flush();
-    RootConsole::wait_for_keypress(true);
+    root.flush();
+    root.wait_for_keypress(true);
 }

--- a/examples/blit.rs
+++ b/examples/blit.rs
@@ -1,0 +1,39 @@
+extern crate tcod;
+
+use tcod::console;
+use tcod::{Console, RootConsole, OffscreenConsole};
+use tcod::colors;
+
+
+fn main() {
+    let mut root = RootConsole::init(80, 50, "Using blit with libtcod", false);
+    
+    let mut direct: OffscreenConsole = OffscreenConsole::new(20, 20);
+    let mut boxed_direct: Box<OffscreenConsole> = Box::new(OffscreenConsole::new(20, 20));
+    let mut trait_object: &Console = &OffscreenConsole::new(20, 20);
+    let mut boxed_trait: Box<Console> = Box::new(OffscreenConsole::new(20, 20));
+
+
+    root.set_default_background(colors::darkest_green);
+    
+    direct.set_default_background(colors::red);
+    boxed_direct.set_default_background(colors::white);
+    trait_object.set_default_background(colors::black);
+    boxed_trait.set_default_background(colors::blue);
+
+    root.clear();
+
+    direct.clear();
+    boxed_direct.clear();
+    trait_object.clear();
+    boxed_trait.clear();
+
+    
+    console::blit(&direct, 0, 0, 20, 20, &mut root, 0, 0, 1.0, 1.0); 
+    console::blit(&boxed_direct, 0, 0, 20, 20, &mut root, 20, 0, 1.0, 1.0); 
+    console::blit(&trait_object, 0, 0, 20, 20, &mut root, 0, 20, 1.0, 1.0); 
+    console::blit(&boxed_trait, 0, 0, 20, 20, &mut root, 20, 20, 1.0, 1.0); 
+
+    RootConsole::flush();
+    RootConsole::wait_for_keypress(true);
+}

--- a/examples/chars.rs
+++ b/examples/chars.rs
@@ -4,7 +4,7 @@ use tcod::{Console, RootConsole};
 use tcod::chars;
 
 fn main() {
-    Console::init_root(80, 50, "Example of libtcod's special chars", false);
+    RootConsole::init(80, 50, "Example of libtcod's special chars", false);
     RootConsole.clear();
 
     // The top half of the box
@@ -22,7 +22,7 @@ fn main() {
     RootConsole.set_char(39, 26, chars::VLINE);
     RootConsole.set_char(39, 25, chars::NW);
 
-    Console::flush();
-    Console::wait_for_keypress(true);
+    RootConsole::flush();
+    RootConsole::wait_for_keypress(true);
 }
 

--- a/examples/chars.rs
+++ b/examples/chars.rs
@@ -4,25 +4,25 @@ use tcod::{Console, RootConsole};
 use tcod::chars;
 
 fn main() {
-    RootConsole::init(80, 50, "Example of libtcod's special chars", false);
-    RootConsole.clear();
+    let mut root = RootConsole::init(80, 50, "Example of libtcod's special chars", false);
+    root.clear();
 
     // The top half of the box
-    RootConsole.set_char(40, 25, chars::HLINE);
-    RootConsole.set_char(41, 25, chars::NE);
-    RootConsole.set_char(41, 26, chars::VLINE);
-    RootConsole.set_char(41, 27, chars::SE);
+    root.set_char(40, 25, chars::HLINE);
+    root.set_char(41, 25, chars::NE);
+    root.set_char(41, 26, chars::VLINE);
+    root.set_char(41, 27, chars::SE);
 
     // Draw the heart:
-    RootConsole.set_char(40, 26, chars::HEART);
+    root.set_char(40, 26, chars::HEART);
 
     // The bottom half of the box
-    RootConsole.set_char(40, 27, chars::HLINE);
-    RootConsole.set_char(39, 27, chars::SW);
-    RootConsole.set_char(39, 26, chars::VLINE);
-    RootConsole.set_char(39, 25, chars::NW);
+    root.set_char(40, 27, chars::HLINE);
+    root.set_char(39, 27, chars::SW);
+    root.set_char(39, 26, chars::VLINE);
+    root.set_char(39, 25, chars::NW);
 
-    RootConsole::flush();
-    RootConsole::wait_for_keypress(true);
+    root.flush();
+    root.wait_for_keypress(true);
 }
 

--- a/examples/colors.rs
+++ b/examples/colors.rs
@@ -28,8 +28,8 @@ fn main() {
     let (h, s, v) = red.hsv();
     println!("Red colour's hue: {}, saturation: {}, value: {}", h, s, v);
 
-    RootConsole::flush();
+    con.flush();
 
     // Press any key to exit:
-    RootConsole::wait_for_keypress(true);
+    con.wait_for_keypress(true);
 }

--- a/examples/colors.rs
+++ b/examples/colors.rs
@@ -1,11 +1,11 @@
 extern crate tcod;
 
-use tcod::{Console, Color, BackgroundFlag};
+use tcod::{Console, RootConsole, Color, BackgroundFlag};
 use tcod::colors;
 
 
 fn main() {
-    let mut con = Console::init_root(80, 50, "Using colours with libtcod", false);
+    let mut con = RootConsole::init(80, 50, "Using colours with libtcod", false);
     con.set_default_background(colors::darkest_green);
     con.set_default_foreground(colors::lighter_azure);
 
@@ -28,8 +28,8 @@ fn main() {
     let (h, s, v) = red.hsv();
     println!("Red colour's hue: {}, saturation: {}, value: {}", h, s, v);
 
-    Console::flush();
+    RootConsole::flush();
 
     // Press any key to exit:
-    Console::wait_for_keypress(true);
+    RootConsole::wait_for_keypress(true);
 }

--- a/examples/fov.rs
+++ b/examples/fov.rs
@@ -48,7 +48,7 @@ fn main() {
 
     root.put_char(20,20, '@', BackgroundFlag::Set);
 
-    RootConsole::flush();
+    root.flush();
     //Press any key to exit.
-    RootConsole::wait_for_keypress(true);
+    root.wait_for_keypress(true);
 }

--- a/examples/fov.rs
+++ b/examples/fov.rs
@@ -1,7 +1,7 @@
 extern crate rand;
 extern crate tcod;
 
-use tcod::{Console, BackgroundFlag, Map};
+use tcod::{Console, RootConsole, BackgroundFlag, Map};
 use tcod::map::FovAlgorithm;
 
 // We'll use a basic structure to define our tiles.
@@ -13,7 +13,7 @@ pub struct Tile {
 }
 
 fn main() {
-    let mut root = Console::init_root(40,40, "FOV example", false);
+    let mut root = RootConsole::init(40,40, "FOV example", false);
     let mut map = Map::new(40,40);
 
     let mut tiles = Vec::new();
@@ -48,7 +48,7 @@ fn main() {
 
     root.put_char(20,20, '@', BackgroundFlag::Set);
 
-    Console::flush();
+    RootConsole::flush();
     //Press any key to exit.
-    Console::wait_for_keypress(true);
+    RootConsole::wait_for_keypress(true);
 }

--- a/examples/keyboard.rs
+++ b/examples/keyboard.rs
@@ -8,11 +8,11 @@ fn main() {
     let mut con = RootConsole::init(80, 50, "libtcod Rust tutorial", false);
     let mut x = 40;
     let mut y = 25;
-    while !RootConsole::window_closed() {
+    while !con.window_closed() {
         con.clear();
         con.put_char(x, y, '@', BackgroundFlag::Set);
-        RootConsole::flush();
-        let keypress = RootConsole::wait_for_keypress(true);
+        con.flush();
+        let keypress = con.wait_for_keypress(true);
         // libtcod 1.5.1 has a bug where `wait_for_keypress` emits two events:
         // one for key down and one for key up. So we ignore the "key up" ones.
         if keypress.pressed {

--- a/examples/keyboard.rs
+++ b/examples/keyboard.rs
@@ -1,18 +1,18 @@
 extern crate tcod;
 
-use tcod::{Console, BackgroundFlag};
+use tcod::{Console, RootConsole, BackgroundFlag};
 use tcod::input::Key::Special;
 use tcod::input::KeyCode::{Up, Down, Left, Right, Escape};
 
 fn main() {
-    let mut con = Console::init_root(80, 50, "libtcod Rust tutorial", false);
+    let mut con = RootConsole::init(80, 50, "libtcod Rust tutorial", false);
     let mut x = 40;
     let mut y = 25;
-    while !Console::window_closed() {
+    while !RootConsole::window_closed() {
         con.clear();
         con.put_char(x, y, '@', BackgroundFlag::Set);
-        Console::flush();
-        let keypress = Console::wait_for_keypress(true);
+        RootConsole::flush();
+        let keypress = RootConsole::wait_for_keypress(true);
         // libtcod 1.5.1 has a bug where `wait_for_keypress` emits two events:
         // one for key down and one for key up. So we ignore the "key up" ones.
         if keypress.pressed {

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -3,10 +3,10 @@ extern crate tcod;
 use tcod::RootConsole;
 
 fn main() {
-    RootConsole::init(80, 50, "Minimal libtcod loop", false);
-    while !RootConsole::window_closed() {
-        RootConsole::flush();
-        let key = RootConsole::wait_for_keypress(true);
+    let mut root = RootConsole::init(80, 50, "Minimal libtcod loop", false);
+    while !root.window_closed() {
+        root.flush();
+        let key = root.wait_for_keypress(true);
         println!("Pressed key: {:?}", key);
     }
 }

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -1,12 +1,12 @@
 extern crate tcod;
 
-use tcod::Console;
+use tcod::RootConsole;
 
 fn main() {
-    Console::init_root(80, 50, "Minimal libtcod loop", false);
-    while !Console::window_closed() {
-        Console::flush();
-        let key = Console::wait_for_keypress(true);
+    RootConsole::init(80, 50, "Minimal libtcod loop", false);
+    while !RootConsole::window_closed() {
+        RootConsole::flush();
+        let key = RootConsole::wait_for_keypress(true);
         println!("Pressed key: {:?}", key);
     }
 }

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -1,15 +1,15 @@
 extern crate tcod;
 
 use tcod::input as input;
-use tcod::{Console, BackgroundFlag};
+use tcod::{Console, RootConsole, BackgroundFlag};
 
 fn main() {
-    let mut con = Console::init_root(
+    let mut con = RootConsole::init(
         80, 50, "Move the cursor inside the window", false);
     let mut x = 40;
     let mut y = 25;
 
-    while !Console::window_closed() {
+    while !RootConsole::window_closed() {
 
         loop {
             match input::check_for_event(input::KEY | input::MOUSE) {
@@ -33,6 +33,6 @@ fn main() {
 
         con.clear();
         con.put_char(x, y, '@', BackgroundFlag::Set);
-        Console::flush();
+        RootConsole::flush();
     }
 }

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -9,7 +9,7 @@ fn main() {
     let mut x = 40;
     let mut y = 25;
 
-    while !RootConsole::window_closed() {
+    while !con.window_closed() {
 
         loop {
             match input::check_for_event(input::KEY | input::MOUSE) {
@@ -33,6 +33,6 @@ fn main() {
 
         con.clear();
         con.put_char(x, y, '@', BackgroundFlag::Set);
-        RootConsole::flush();
+        con.flush();
     }
 }

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -3,15 +3,15 @@ extern crate tcod;
 use tcod::{Console, RootConsole, BackgroundFlag, TextAlignment};
 
 fn main() {
-    RootConsole::init(80, 50, "Displaying text", false);
-    RootConsole.print_ex(1, 1, BackgroundFlag::None, TextAlignment::Left,
-                         "Text aligned to left.");
-    RootConsole.print_ex(78, 1, BackgroundFlag::None, TextAlignment::Right,
-                         "Text aligned to right.");
-    RootConsole.print_ex(40, 15, BackgroundFlag::None, TextAlignment::Center,
-                         "And this bit of text is centered.");
-    RootConsole.print_ex(40, 19, BackgroundFlag::None, TextAlignment::Center,
-                         "Press any key to quit.");
-    RootConsole::flush();
-    RootConsole::wait_for_keypress(true);
+    let mut root = RootConsole::init(80, 50, "Displaying text", false);
+    root.print_ex(1, 1, BackgroundFlag::None, TextAlignment::Left,
+                  "Text aligned to left.");
+    root.print_ex(78, 1, BackgroundFlag::None, TextAlignment::Right,
+                  "Text aligned to right.");
+    root.print_ex(40, 15, BackgroundFlag::None, TextAlignment::Center,
+                  "And this bit of text is centered.");
+    root.print_ex(40, 19, BackgroundFlag::None, TextAlignment::Center,
+                  "Press any key to quit.");
+    root.flush();
+    root.wait_for_keypress(true);
 }

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -3,7 +3,7 @@ extern crate tcod;
 use tcod::{Console, RootConsole, BackgroundFlag, TextAlignment};
 
 fn main() {
-    Console::init_root(80, 50, "Displaying text", false);
+    RootConsole::init(80, 50, "Displaying text", false);
     RootConsole.print_ex(1, 1, BackgroundFlag::None, TextAlignment::Left,
                          "Text aligned to left.");
     RootConsole.print_ex(78, 1, BackgroundFlag::None, TextAlignment::Right,
@@ -12,6 +12,6 @@ fn main() {
                          "And this bit of text is centered.");
     RootConsole.print_ex(40, 19, BackgroundFlag::None, TextAlignment::Center,
                          "Press any key to quit.");
-    Console::flush();
-    Console::wait_for_keypress(true);
+    RootConsole::flush();
+    RootConsole::wait_for_keypress(true);
 }

--- a/src/console.rs
+++ b/src/console.rs
@@ -6,13 +6,12 @@ use bindings::{c_bool, c_uint, CString, keycode_from_u32};
 use colors::Color;
 use input::{Key, KeyPressFlags, KeyState};
 
-// Private wrapper over TCOD_console_t. Ideally, we'd have it as a private field
-// in OffscreenConsole, but that doesn't seem to be possible now.
-pub struct LibtcodConsole {
+
+pub struct OffscreenConsole {
     con: ffi::TCOD_console_t,
 }
 
-impl Drop for LibtcodConsole {
+impl Drop for OffscreenConsole {
     fn drop(&mut self) {
         unsafe {
             ffi::TCOD_console_delete(self.con);
@@ -20,32 +19,20 @@ impl Drop for LibtcodConsole {
     }
 }
 
-pub enum Console {
-    Root,
-    Offscreen(LibtcodConsole)
-}
-
-impl Console {
-    pub fn new(width: i32, height: i32) -> Console {
+impl OffscreenConsole {
+    pub fn new(width: i32, height: i32) -> OffscreenConsole {
         assert!(width > 0 && height > 0);
         unsafe {
-            Console::Offscreen(
-                LibtcodConsole{
-                    con: ffi::TCOD_console_new(width, height)
-                }
-            )
+            OffscreenConsole { con: ffi::TCOD_console_new(width, height) }
         }
     }
 
-    #[inline]
-    fn con(&self) -> ffi::TCOD_console_t {
-        match self {
-            &Console::Root => 0 as ffi::TCOD_console_t,
-            &Console::Offscreen(LibtcodConsole{con}) => con,
-        }
-    }
+}
 
-    pub fn init_root(width: i32, height: i32, title: &str, fullscreen: bool) -> Console {
+pub struct RootConsole;
+
+impl RootConsole {
+    pub fn init(width: i32, height: i32, title: &str, fullscreen: bool) -> RootConsole {
         assert!(width > 0 && height > 0);
         unsafe {
             let c_title = CString::new(title.as_bytes()).unwrap();
@@ -54,9 +41,9 @@ impl Console {
                                         fullscreen as c_bool,
                                         ffi::TCOD_RENDERER_SDL);
         }
-        Console::Root
+        RootConsole
     }
-
+    
     pub fn is_fullscreen() -> bool {
         unsafe {
             ffi::TCOD_console_is_fullscreen() != 0
@@ -81,211 +68,6 @@ impl Console {
         }
     }
 
-    pub fn get_alignment(&self) -> TextAlignment {
-        let alignment = unsafe {
-            ffi::TCOD_console_get_alignment(self.con())
-        };
-        match alignment {
-            ffi::TCOD_LEFT => TextAlignment::Left,
-            ffi::TCOD_RIGHT => TextAlignment::Right,
-            ffi::TCOD_CENTER => TextAlignment::Center,
-            _ => unreachable!(),
-        }
-    }
-
-    pub fn set_alignment(&mut self, alignment: TextAlignment) {
-        unsafe {
-            ffi::TCOD_console_set_alignment(self.con(), alignment as u32);
-        }
-    }
-
-    pub fn blit(source_console: &Console,
-                source_x: i32, source_y: i32,
-                source_width: i32, source_height: i32,
-                destination_console: &mut Console,
-                destination_x: i32, destination_y: i32,
-                foreground_alpha: f32, background_alpha: f32) {
-        assert!(source_x >= 0 && source_y >= 0 &&
-                source_width > 0 && source_height > 0 &&
-                destination_x >= 0 && destination_y >= 0);
-        unsafe {
-            ffi::TCOD_console_blit(source_console.con(),
-                                   source_x, source_y,
-                                   source_width, source_height,
-                                   destination_console.con(),
-                                   destination_x, destination_y,
-                                   foreground_alpha, background_alpha)
-        }
-    }
-
-    pub fn set_key_color(&mut self, color: Color) {
-        unsafe {
-            ffi::TCOD_console_set_key_color(self.con(), color.to_color_t());
-        }
-    }
-
-    pub fn width(&self) -> i32 {
-        unsafe {
-            ffi::TCOD_console_get_width(self.con())
-        }
-    }
-
-    pub fn height(&self) -> i32 {
-        unsafe {
-            ffi::TCOD_console_get_height(self.con())
-        }
-    }
-
-    pub fn set_default_background(&mut self, color: Color) {
-        unsafe {
-            ffi::TCOD_console_set_default_background(self.con(), color.to_color_t());
-        }
-    }
-
-    pub fn set_default_foreground(&mut self, color: Color) {
-        unsafe {
-            ffi::TCOD_console_set_default_foreground(self.con(), color.to_color_t());
-        }
-    }
-
-    pub fn console_set_key_color(&mut self, color: Color) {
-        unsafe {
-            ffi::TCOD_console_set_key_color(self.con(), color.to_color_t());
-        }
-    }
-
-    pub fn get_char_background(&self, x: i32, y: i32) -> Color {
-        unsafe {
-            Color::from_tcod_color_t(
-                ffi::TCOD_console_get_char_background(self.con(), x, y))
-        }
-    }
-
-    pub fn get_char_foreground(&self, x: i32, y: i32) -> Color {
-        unsafe {
-            Color::from_tcod_color_t(
-                ffi::TCOD_console_get_char_foreground(self.con(), x, y))
-        }
-    }
-
-    pub fn get_background_flag(&self) -> BackgroundFlag {
-        let flag = unsafe {
-            ffi::TCOD_console_get_background_flag(self.con())
-        };
-        match flag {
-            ffi::TCOD_BKGND_NONE => BackgroundFlag::None,
-            ffi::TCOD_BKGND_SET => BackgroundFlag::Set,
-            ffi::TCOD_BKGND_MULTIPLY => BackgroundFlag::Multiply,
-            ffi::TCOD_BKGND_LIGHTEN => BackgroundFlag::Lighten,
-            ffi::TCOD_BKGND_DARKEN => BackgroundFlag::Darken,
-            ffi::TCOD_BKGND_SCREEN => BackgroundFlag::Screen,
-            ffi::TCOD_BKGND_COLOR_DODGE => BackgroundFlag::ColorDodge,
-            ffi::TCOD_BKGND_COLOR_BURN => BackgroundFlag::ColorBurn,
-            ffi::TCOD_BKGND_ADD => BackgroundFlag::Add,
-            ffi::TCOD_BKGND_ADDA => BackgroundFlag::AddA,
-            ffi::TCOD_BKGND_BURN => BackgroundFlag::Burn,
-            ffi::TCOD_BKGND_OVERLAY => BackgroundFlag::Overlay,
-            ffi::TCOD_BKGND_ALPH => BackgroundFlag::Alph,
-            ffi::TCOD_BKGND_DEFAULT => BackgroundFlag::Default,
-            _ => unreachable!(),
-        }
-    }
-
-    pub fn set_background_flag(&mut self, background_flag: BackgroundFlag) {
-        unsafe {
-            ffi::TCOD_console_set_background_flag(self.con(),
-                                                  background_flag as u32);
-        }
-    }
-
-    pub fn get_char(&self, x: i32, y: i32) -> char {
-        let ffi_char = unsafe {
-            ffi::TCOD_console_get_char(self.con(), x, y)
-        };
-        assert!(ffi_char >= 0 && ffi_char < 256);
-        ffi_char as u8 as char
-    }
-
-    pub fn set_char(&mut self, x: i32, y: i32, c: char) {
-        assert!(x >= 0 && y >= 0);
-        unsafe {
-            ffi::TCOD_console_set_char(self.con(), x, y, c as i32)
-        }
-    }
-
-    pub fn set_char_background(&mut self, x: i32, y: i32,
-                               color: Color,
-                               background_flag: BackgroundFlag) {
-        assert!(x >= 0 && y >= 0);
-        unsafe {
-            ffi::TCOD_console_set_char_background(self.con(),
-                                                  x, y,
-                                                  color.to_color_t(),
-                                                  background_flag as u32)
-        }
-    }
-
-    pub fn set_char_foreground(&mut self, x: i32, y: i32, color: Color) {
-        assert!(x >= 0 && y >= 0);
-        unsafe {
-            ffi::TCOD_console_set_char_foreground(self.con(),
-                                                  x, y,
-                                                  color.to_color_t());
-        }
-    }
-
-    pub fn put_char(&mut self,
-                    x: i32, y: i32, glyph: char,
-                    background_flag: BackgroundFlag) {
-        assert!(x >= 0 && y >= 0);
-        unsafe {
-            ffi::TCOD_console_put_char(self.con(),
-                                       x, y, glyph as i32,
-                                       background_flag as u32);
-        }
-    }
-
-    pub fn put_char_ex(&mut self,
-                       x: i32, y: i32, glyph: char,
-                       foreground: Color, background: Color) {
-        assert!(x >= 0 && y >= 0);
-        unsafe {
-            ffi::TCOD_console_put_char_ex(self.con(),
-                                          x, y, glyph as i32,
-                                          foreground.to_color_t(),
-                                          background.to_color_t());
-        }
-    }
-
-    pub fn clear(&mut self) {
-        unsafe {
-            ffi::TCOD_console_clear(self.con());
-        }
-    }
-
-    pub fn print(&mut self, x: i32, y: i32, text: &str) {
-        assert!(x >= 0 && y >= 0);
-        unsafe {
-            let c_text = CString::new(text.as_bytes()).unwrap();
-            ffi::TCOD_console_print(self.con(), x, y, c_text.as_ptr());
-        }
-    }
-
-    pub fn print_ex(&mut self,
-                    x: i32, y: i32,
-                    background_flag: BackgroundFlag,
-                    alignment: TextAlignment,
-                    text: &str) {
-        assert!(x >= 0 && y >= 0);
-        unsafe {
-            let c_text = CString::new(text.as_bytes()).unwrap();
-            ffi::TCOD_console_print_ex(self.con(),
-                                        x, y,
-                                        background_flag as u32,
-                                        alignment as u32,
-                                        c_text.as_ptr());
-        }
-    }
 
     pub fn get_fade() -> u8 {
         unsafe {
@@ -380,6 +162,252 @@ impl Console {
         }
     }
 }
+
+
+pub trait Console {
+    fn con(&self) -> ffi::TCOD_console_t;
+
+    fn get_alignment(&self) -> TextAlignment {
+        let alignment = unsafe {
+            ffi::TCOD_console_get_alignment(self.con())
+        };
+        match alignment {
+            ffi::TCOD_LEFT => TextAlignment::Left,
+            ffi::TCOD_RIGHT => TextAlignment::Right,
+            ffi::TCOD_CENTER => TextAlignment::Center,
+            _ => unreachable!(),
+        }
+    }
+    
+    fn set_alignment(&mut self, alignment: TextAlignment) {
+        unsafe {
+            ffi::TCOD_console_set_alignment(self.con(), alignment as u32);
+        }
+    }
+     
+    fn set_key_color(&mut self, color: Color) {
+        unsafe {
+            ffi::TCOD_console_set_key_color(self.con(), color.to_color_t());
+        }
+    }
+
+    fn width(&self) -> i32 {
+        unsafe {
+            ffi::TCOD_console_get_width(self.con())
+        }
+    }
+
+    fn height(&self) -> i32 {
+        unsafe {
+            ffi::TCOD_console_get_height(self.con())
+        }
+    }
+
+    fn set_default_background(&mut self, color: Color) {
+        unsafe {
+            ffi::TCOD_console_set_default_background(self.con(), color.to_color_t());
+        }
+    }
+
+    fn set_default_foreground(&mut self, color: Color) {
+        unsafe {
+            ffi::TCOD_console_set_default_foreground(self.con(), color.to_color_t());
+        }
+    }
+
+    fn console_set_key_color(&mut self, color: Color) {
+        unsafe {
+            ffi::TCOD_console_set_key_color(self.con(), color.to_color_t());
+        }
+    }
+
+    fn get_char_background(&self, x: i32, y: i32) -> Color {
+        unsafe {
+            Color::from_tcod_color_t(
+                ffi::TCOD_console_get_char_background(self.con(), x, y))
+        }
+    }
+
+    fn get_char_foreground(&self, x: i32, y: i32) -> Color {
+        unsafe {
+            Color::from_tcod_color_t(
+                ffi::TCOD_console_get_char_foreground(self.con(), x, y))
+        }
+    }
+
+    fn get_background_flag(&self) -> BackgroundFlag {
+        let flag = unsafe {
+            ffi::TCOD_console_get_background_flag(self.con())
+        };
+        match flag {
+            ffi::TCOD_BKGND_NONE => BackgroundFlag::None,
+            ffi::TCOD_BKGND_SET => BackgroundFlag::Set,
+            ffi::TCOD_BKGND_MULTIPLY => BackgroundFlag::Multiply,
+            ffi::TCOD_BKGND_LIGHTEN => BackgroundFlag::Lighten,
+            ffi::TCOD_BKGND_DARKEN => BackgroundFlag::Darken,
+            ffi::TCOD_BKGND_SCREEN => BackgroundFlag::Screen,
+            ffi::TCOD_BKGND_COLOR_DODGE => BackgroundFlag::ColorDodge,
+            ffi::TCOD_BKGND_COLOR_BURN => BackgroundFlag::ColorBurn,
+            ffi::TCOD_BKGND_ADD => BackgroundFlag::Add,
+            ffi::TCOD_BKGND_ADDA => BackgroundFlag::AddA,
+            ffi::TCOD_BKGND_BURN => BackgroundFlag::Burn,
+            ffi::TCOD_BKGND_OVERLAY => BackgroundFlag::Overlay,
+            ffi::TCOD_BKGND_ALPH => BackgroundFlag::Alph,
+            ffi::TCOD_BKGND_DEFAULT => BackgroundFlag::Default,
+            _ => unreachable!(),
+        }
+    }
+
+    fn set_background_flag(&mut self, background_flag: BackgroundFlag) {
+        unsafe {
+            ffi::TCOD_console_set_background_flag(self.con(),
+                                                  background_flag as u32);
+        }
+    }
+
+    fn get_char(&self, x: i32, y: i32) -> char {
+        let ffi_char = unsafe {
+            ffi::TCOD_console_get_char(self.con(), x, y)
+        };
+        assert!(ffi_char >= 0 && ffi_char < 256);
+        ffi_char as u8 as char
+    }
+
+    fn set_char(&mut self, x: i32, y: i32, c: char) {
+        assert!(x >= 0 && y >= 0);
+        unsafe {
+            ffi::TCOD_console_set_char(self.con(), x, y, c as i32)
+        }
+    }
+
+    fn set_char_background(&mut self, x: i32, y: i32,
+                           color: Color,
+                           background_flag: BackgroundFlag) {
+        assert!(x >= 0 && y >= 0);
+        unsafe {
+            ffi::TCOD_console_set_char_background(self.con(),
+                                                  x, y,
+                                                  color.to_color_t(),
+                                                  background_flag as u32)
+        }
+    }
+
+    fn set_char_foreground(&mut self, x: i32, y: i32, color: Color) {
+        assert!(x >= 0 && y >= 0);
+        unsafe {
+            ffi::TCOD_console_set_char_foreground(self.con(),
+                                                  x, y,
+                                                  color.to_color_t());
+        }
+    }
+
+    fn put_char(&mut self,
+                x: i32, y: i32, glyph: char,
+                background_flag: BackgroundFlag) {
+        assert!(x >= 0 && y >= 0);
+        unsafe {
+            ffi::TCOD_console_put_char(self.con(),
+                                       x, y, glyph as i32,
+                                       background_flag as u32);
+        }
+    }
+
+    fn put_char_ex(&mut self,
+                   x: i32, y: i32, glyph: char,
+                   foreground: Color, background: Color) {
+        assert!(x >= 0 && y >= 0);
+        unsafe {
+            ffi::TCOD_console_put_char_ex(self.con(),
+                                          x, y, glyph as i32,
+                                          foreground.to_color_t(),
+                                          background.to_color_t());
+        }
+    }
+
+    fn clear(&mut self) {
+        unsafe {
+            ffi::TCOD_console_clear(self.con());
+        }
+    }
+
+    fn print(&mut self, x: i32, y: i32, text: &str) {
+        assert!(x >= 0 && y >= 0);
+        unsafe {
+            let c_text = CString::new(text.as_bytes()).unwrap();
+            ffi::TCOD_console_print(self.con(), x, y, c_text.as_ptr());
+        }
+    }
+
+    fn print_ex(&mut self,
+                x: i32, y: i32,
+                background_flag: BackgroundFlag,
+                alignment: TextAlignment,
+                text: &str) {
+        assert!(x >= 0 && y >= 0);
+        unsafe {
+            let c_text = CString::new(text.as_bytes()).unwrap();
+            ffi::TCOD_console_print_ex(self.con(),
+                                       x, y,
+                                       background_flag as u32,
+                                       alignment as u32,
+                                       c_text.as_ptr());
+        }
+    }
+}
+
+pub fn blit<T, U>(source_console: &T,
+                  source_x: i32, source_y: i32,
+                  source_width: i32, source_height: i32,
+                  destination_console: &mut U,
+                  destination_x: i32, destination_y: i32,
+                  foreground_alpha: f32, background_alpha: f32)
+    where T: Console,
+          U: Console {
+    unsafe {
+        ffi::TCOD_console_blit(source_console.con(),
+                               source_x, source_y, source_width, source_height,
+                               destination_console.con(), 
+                               destination_x, destination_y,
+                               foreground_alpha, background_alpha);
+    }
+}
+
+impl<'a> Console for &'a Console {
+    fn con(&self) -> ffi::TCOD_console_t {
+        (*self).con()
+    }
+}
+
+impl Console for Box<Console> {
+    fn con(&self) -> ffi::TCOD_console_t {
+        (**self).con()
+    }
+}
+
+impl Console for RootConsole {
+    fn con(&self) -> ffi::TCOD_console_t {
+        0 as ffi::TCOD_console_t
+    }
+}
+
+impl Console for Box<RootConsole> {
+    fn con(&self) -> ffi::TCOD_console_t {
+        (**self).con()
+    }
+}
+
+impl Console for OffscreenConsole {
+    fn con(&self) -> ffi::TCOD_console_t {
+        self.con
+    }
+}
+
+impl Console for Box<OffscreenConsole> {
+    fn con(&self) -> ffi::TCOD_console_t {
+        (**self).con()
+    }
+}
+
 
 #[repr(C)]
 #[derive(Copy, Clone)]

--- a/src/console.rs
+++ b/src/console.rs
@@ -7,11 +7,11 @@ use colors::Color;
 use input::{Key, KeyPressFlags, KeyState};
 
 
-pub struct OffscreenConsole {
+pub struct Offscreen {
     con: ffi::TCOD_console_t,
 }
 
-impl Drop for OffscreenConsole {
+impl Drop for Offscreen {
     fn drop(&mut self) {
         unsafe {
             ffi::TCOD_console_delete(self.con);
@@ -19,20 +19,20 @@ impl Drop for OffscreenConsole {
     }
 }
 
-impl OffscreenConsole {
-    pub fn new(width: i32, height: i32) -> OffscreenConsole {
+impl Offscreen {
+    pub fn new(width: i32, height: i32) -> Offscreen {
         assert!(width > 0 && height > 0);
         unsafe {
-            OffscreenConsole { con: ffi::TCOD_console_new(width, height) }
+            Offscreen { con: ffi::TCOD_console_new(width, height) }
         }
     }
 
 }
 
-pub struct RootConsole;
+pub struct Root;
 
-impl RootConsole {
-    pub fn init(width: i32, height: i32, title: &str, fullscreen: bool) -> RootConsole {
+impl Root {
+    pub fn init(width: i32, height: i32, title: &str, fullscreen: bool) -> Root {
         assert!(width > 0 && height > 0);
         unsafe {
             let c_title = CString::new(title.as_bytes()).unwrap();
@@ -41,7 +41,7 @@ impl RootConsole {
                                         fullscreen as c_bool,
                                         ffi::TCOD_RENDERER_SDL);
         }
-        RootConsole
+        Root
     }
     
     pub fn is_fullscreen(&self) -> bool {
@@ -385,25 +385,25 @@ impl Console for Box<Console> {
     }
 }
 
-impl Console for RootConsole {
+impl Console for Root {
     unsafe fn con(&self) -> ffi::TCOD_console_t {
         0 as ffi::TCOD_console_t
     }
 }
 
-impl Console for Box<RootConsole> {
+impl Console for Box<Root> {
     unsafe fn con(&self) -> ffi::TCOD_console_t {
         (**self).con()
     }
 }
 
-impl Console for OffscreenConsole {
+impl Console for Offscreen {
     unsafe fn con(&self) -> ffi::TCOD_console_t {
         self.con
     }
 }
 
-impl Console for Box<OffscreenConsole> {
+impl Console for Box<Offscreen> {
     unsafe fn con(&self) -> ffi::TCOD_console_t {
         (**self).con()
     }

--- a/src/console.rs
+++ b/src/console.rs
@@ -166,7 +166,7 @@ impl RootConsole {
 
 
 pub trait Console {
-    fn con(&self) -> ffi::TCOD_console_t;
+    unsafe fn con(&self) -> ffi::TCOD_console_t;
 
     fn get_alignment(&self) -> TextAlignment {
         let alignment = unsafe {
@@ -374,37 +374,37 @@ pub fn blit<T, U>(source_console: &T,
 }
 
 impl<'a> Console for &'a Console {
-    fn con(&self) -> ffi::TCOD_console_t {
+    unsafe fn con(&self) -> ffi::TCOD_console_t {
         (*self).con()
     }
 }
 
 impl Console for Box<Console> {
-    fn con(&self) -> ffi::TCOD_console_t {
+    unsafe fn con(&self) -> ffi::TCOD_console_t {
         (**self).con()
     }
 }
 
 impl Console for RootConsole {
-    fn con(&self) -> ffi::TCOD_console_t {
+    unsafe fn con(&self) -> ffi::TCOD_console_t {
         0 as ffi::TCOD_console_t
     }
 }
 
 impl Console for Box<RootConsole> {
-    fn con(&self) -> ffi::TCOD_console_t {
+    unsafe fn con(&self) -> ffi::TCOD_console_t {
         (**self).con()
     }
 }
 
 impl Console for OffscreenConsole {
-    fn con(&self) -> ffi::TCOD_console_t {
+    unsafe fn con(&self) -> ffi::TCOD_console_t {
         self.con
     }
 }
 
 impl Console for Box<OffscreenConsole> {
-    fn con(&self) -> ffi::TCOD_console_t {
+    unsafe fn con(&self) -> ffi::TCOD_console_t {
         (**self).con()
     }
 }

--- a/src/console.rs
+++ b/src/console.rs
@@ -44,51 +44,52 @@ impl RootConsole {
         RootConsole
     }
     
-    pub fn is_fullscreen() -> bool {
+    pub fn is_fullscreen(&self) -> bool {
         unsafe {
             ffi::TCOD_console_is_fullscreen() != 0
         }
     }
 
-    pub fn set_fullscreen(fullscreen: bool) {
+    pub fn set_fullscreen(&mut self, fullscreen: bool) {
         unsafe {
             ffi::TCOD_console_set_fullscreen(fullscreen as u8);
         }
     }
 
-    pub fn disable_keyboard_repeat() {
+    pub fn disable_keyboard_repeat(&mut self) {
         unsafe {
             ffi::TCOD_console_disable_keyboard_repeat()
         }
     }
 
-    pub fn is_active() -> bool {
+    pub fn is_active(&self) -> bool {
         unsafe {
             ffi::TCOD_console_is_active() != 0
         }
     }
 
 
-    pub fn get_fade() -> u8 {
+    pub fn get_fade(&self) -> u8 {
         unsafe {
             ffi::TCOD_console_get_fade()
         }
     }
 
-    pub fn get_fading_color() -> Color {
+    pub fn get_fading_color(&self) -> Color {
         unsafe {
             Color::from_tcod_color_t(
                 ffi::TCOD_console_get_fading_color())
         }
     }
 
-    pub fn set_fade(fade: u8, fading_color: Color) {
+    pub fn set_fade(&mut self, fade: u8, fading_color: Color) {
         unsafe {
             ffi::TCOD_console_set_fade(fade, fading_color.to_color_t());
         }
     }
 
-    pub fn set_custom_font(font_path: &std::path::Path, flags: FontFlags,
+    pub fn set_custom_font(&mut self, 
+                           font_path: &std::path::Path, flags: FontFlags,
                            nb_char_horizontal: i32,
                            nb_char_vertical: i32) {
         unsafe {
@@ -100,7 +101,7 @@ impl RootConsole {
         }
     }
 
-    pub fn wait_for_keypress(flush: bool) -> KeyState {
+    pub fn wait_for_keypress(&mut self, flush: bool) -> KeyState {
         let tcod_key = unsafe {
             ffi::TCOD_console_wait_for_keypress(flush as c_bool)
         };
@@ -120,7 +121,7 @@ impl RootConsole {
         }
     }
 
-    pub fn check_for_keypress(status: KeyPressFlags) -> Option<KeyState> {
+    pub fn check_for_keypress(&self, status: KeyPressFlags) -> Option<KeyState> {
         let tcod_key = unsafe {
             ffi::TCOD_console_check_for_keypress(status.bits() as i32)
         };
@@ -143,19 +144,19 @@ impl RootConsole {
         })
     }
 
-    pub fn window_closed() -> bool {
+    pub fn window_closed(&self) -> bool {
         unsafe {
             ffi::TCOD_console_is_window_closed() != 0
         }
     }
 
-    pub fn flush() {
+    pub fn flush(&mut self) {
         unsafe {
             ffi::TCOD_console_flush();
         }
     }
 
-    pub fn set_window_title(title: &str) {
+    pub fn set_window_title(&mut self, title: &str) {
         unsafe {
             let c_title = CString::new(title.as_bytes()).unwrap();
             ffi::TCOD_console_set_window_title(c_title.as_ptr());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,8 @@
 #[macro_use] extern crate bitflags;
 
 pub use colors::Color;
-pub use console::{Console, BackgroundFlag, Renderer, FontFlags, TextAlignment};
+pub use console::{Console, RootConsole, OffscreenConsole, BackgroundFlag, Renderer, FontFlags, TextAlignment};
 pub use map::Map;
-
-pub use Console::Root as RootConsole;
 
 pub mod chars;
 pub mod colors;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #[macro_use] extern crate bitflags;
 
 pub use colors::Color;
-pub use console::{Console, RootConsole, OffscreenConsole, BackgroundFlag, Renderer, FontFlags, TextAlignment};
+pub use console::{Console, BackgroundFlag, Renderer, FontFlags, TextAlignment};
 pub use map::Map;
 
 pub mod chars;
@@ -15,10 +15,6 @@ pub mod system;
 mod bindings;
 
 
-
-
-
-
-
-
+pub type RootConsole = console::Root; 
+pub type OffscreenConsole = console::Offscreen;
 


### PR DESCRIPTION
This still has the names `OffscreenConsole` and `RootConsole`. I'm kind of partial to these, since you can import them nicely from the `console` module and still know what they do.

If the naming is fine as it is, then this closes #137  