### PR TITLE
Added Root console initializer

### DIFF
--- a/examples/blit.rs
+++ b/examples/blit.rs
@@ -6,7 +6,10 @@ use tcod::colors;
 
 
 fn main() {
-    let mut root = RootConsole::init(80, 50, "Using blit with libtcod", false);
+    let mut root = RootConsole::initializer()
+        .size(80, 50)
+        .title("Using blit with libtcod")
+        .init();
     
     let mut direct: OffscreenConsole = OffscreenConsole::new(20, 20);
     let mut boxed_direct: Box<OffscreenConsole> = Box::new(OffscreenConsole::new(20, 20));

--- a/examples/chars.rs
+++ b/examples/chars.rs
@@ -4,7 +4,11 @@ use tcod::{Console, RootConsole};
 use tcod::chars;
 
 fn main() {
-    let mut root = RootConsole::init(80, 50, "Example of libtcod's special chars", false);
+    let mut root = RootConsole::initializer()
+        .size(80, 50)
+        .title("Example of libtcod's special chars")
+        .init();
+
     root.clear();
 
     // The top half of the box

--- a/examples/colors.rs
+++ b/examples/colors.rs
@@ -5,7 +5,11 @@ use tcod::colors;
 
 
 fn main() {
-    let mut con = RootConsole::init(80, 50, "Using colours with libtcod", false);
+    let mut con = RootConsole::initializer()
+        .size(80, 50)
+        .title("Using colours with libtcod")
+        .init();
+
     con.set_default_background(colors::darkest_green);
     con.set_default_foreground(colors::lighter_azure);
 

--- a/examples/fov.rs
+++ b/examples/fov.rs
@@ -13,9 +13,9 @@ pub struct Tile {
 }
 
 fn main() {
-    let mut root = RootConsole::init(40,40, "FOV example", false);
-    let mut map = Map::new(40,40);
+    let mut root = RootConsole::initializer().size(40, 40) .title("FOV example").init();
 
+    let mut map = Map::new(40,40);
     let mut tiles = Vec::new();
 
     root.clear();

--- a/examples/keyboard.rs
+++ b/examples/keyboard.rs
@@ -5,7 +5,11 @@ use tcod::input::Key::Special;
 use tcod::input::KeyCode::{Up, Down, Left, Right, Escape};
 
 fn main() {
-    let mut con = RootConsole::init(80, 50, "libtcod Rust tutorial", false);
+    let mut con = RootConsole::initializer()
+        .size(80, 50)
+        .title("libtcod Rust tutorial")
+        .init();
+
     let mut x = 40;
     let mut y = 25;
     while !con.window_closed() {

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -3,7 +3,8 @@ extern crate tcod;
 use tcod::RootConsole;
 
 fn main() {
-    let mut root = RootConsole::init(80, 50, "Minimal libtcod loop", false);
+    let mut root = RootConsole::initializer().size(80, 50).title("Minimal libtcod loop").init();
+
     while !root.window_closed() {
         root.flush();
         let key = root.wait_for_keypress(true);

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -4,8 +4,11 @@ use tcod::input as input;
 use tcod::{Console, RootConsole, BackgroundFlag};
 
 fn main() {
-    let mut con = RootConsole::init(
-        80, 50, "Move the cursor inside the window", false);
+    let mut con = RootConsole::initializer()
+        .size(80, 50)
+        .title("Move the cursor inside the window")
+        .init();
+
     let mut x = 40;
     let mut y = 25;
 

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -3,7 +3,8 @@ extern crate tcod;
 use tcod::{Console, RootConsole, BackgroundFlag, TextAlignment};
 
 fn main() {
-    let mut root = RootConsole::init(80, 50, "Displaying text", false);
+    let mut root = RootConsole::initializer().size(80, 50).title("Displaying text").init();
+
     root.print_ex(1, 1, BackgroundFlag::None, TextAlignment::Left,
                   "Text aligned to left.");
     root.print_ex(78, 1, BackgroundFlag::None, TextAlignment::Right,

--- a/src/console.rs
+++ b/src/console.rs
@@ -66,7 +66,6 @@ impl Root {
             Windowed => false
         };
         
-        println!("{} {}", width, height);
         unsafe {
             let c_title = CString::new(title.as_bytes()).unwrap();
             ffi::TCOD_console_init_root(width, height,

--- a/src/console.rs
+++ b/src/console.rs
@@ -51,7 +51,8 @@ impl Root {
     }
     
     fn init(width: i32, height: i32, title: &str, window_type: WindowType, 
-            font_path: FontPath, flags: FontFlags, font_dimensions: FontDimensions) -> Root {
+            font_path: FontPath, flags: FontFlags, font_dimensions: FontDimensions,
+            renderer: Renderer) -> Root {
         assert!(width > 0 && height > 0);
         
         match (font_path, font_dimensions) {
@@ -71,7 +72,7 @@ impl Root {
             ffi::TCOD_console_init_root(width, height,
                                         c_title.as_ptr(),
                                         fullscreen as c_bool,
-                                        ffi::TCOD_RENDERER_SDL);
+                                        renderer as u32);
         }
         Root
     }
@@ -204,7 +205,8 @@ pub struct RootInitializer<'a> {
     window_type: WindowType,
     font_path: FontPath<'a>,
     font_flags: FontFlags,
-    font_dimension: FontDimensions
+    font_dimension: FontDimensions,
+    console_renderer: Renderer
 }
 
 impl<'a> RootInitializer<'a> {
@@ -216,7 +218,8 @@ impl<'a> RootInitializer<'a> {
             window_type: Windowed,
             font_path: FontPath("terminal.png"),
             font_flags: FONT_LAYOUT_ASCII_INCOL,
-            font_dimension: FontDimensions(0, 0)
+            font_dimension: FontDimensions(0, 0),
+            console_renderer: Renderer::SDL
         }
     }
 
@@ -247,9 +250,15 @@ impl<'a> RootInitializer<'a> {
         self
     }
 
+    pub fn renderer(&mut self, renderer: Renderer) -> &mut RootInitializer<'a> {
+        self.console_renderer = renderer;
+        self
+    }
+
     pub fn init(&self) -> Root {
         Root::init(self.width, self.height, self.title, self.window_type, 
-                   self.font_path, self.font_flags, self.font_dimension)
+                   self.font_path, self.font_flags, self.font_dimension, 
+                   self.console_renderer)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,7 @@
 #[macro_use] extern crate bitflags;
 
 pub use colors::Color;
-pub use console::{Console, RootInitializer, BackgroundFlag, Renderer, Fullscreen, Windowed, 
-                  FontPath, FontDimensions, FontFlags, TextAlignment};
+pub use console::{Console, RootInitializer, BackgroundFlag, Renderer, FontLayout, FontType, TextAlignment};
 pub use map::Map;
 
 pub mod chars;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
 #[macro_use] extern crate bitflags;
 
 pub use colors::Color;
-pub use console::{Console, BackgroundFlag, Renderer, FontFlags, TextAlignment};
+pub use console::{Console, RootInitializer, BackgroundFlag, Renderer, Fullscreen, Windowed, 
+                  FontPath, FontDimensions, FontFlags, TextAlignment};
 pub use map::Map;
 
 pub mod chars;


### PR DESCRIPTION
This implementation matches the latest version discussed in #137 with two modifications: 
1. newtype introduced for font paths, which makes all font-related arguments in the raw `Root` initializer explicit
2. added `Root::initializer()` static function to `Root`. This is to avoid an unnecessary import for `RootInitializer`. The downside is that `init` and `initializer` are fairly similarly named. 

Since this is a one-time function call, I don't think the added verbosity is too bad, and it's much nicer to work with.

Closes #137
Closes #146