### PR TITLE
Update tcod_sys build to work on paths with spaces

### DIFF
--- a/tcod_sys/build.rs
+++ b/tcod_sys/build.rs
@@ -63,5 +63,5 @@ fn main() {
     // TODO: can we (optionally?) produce a static copy? It'd probably be more
     // work, but would be easier for the end users.
     println!("cargo:rustc-link-search=native={}", dst.display());
-    println!("cargo:rustc-link-lib=dylib=libtcod");
+    println!("cargo:rustc-link-lib=dylib=tcod");
 }

--- a/tcod_sys/build.rs
+++ b/tcod_sys/build.rs
@@ -62,5 +62,6 @@ fn main() {
 
     // TODO: can we (optionally?) produce a static copy? It'd probably be more
     // work, but would be easier for the end users.
-    println!("cargo:rustc-flags=-l dylib=tcod -L {}", dst.display())
+    println!("cargo:rustc-link-search=native={}", dst.display());
+    println!("cargo:rustc-link-lib=dylib=libtcod");
 }

--- a/tcod_sys/build.rs
+++ b/tcod_sys/build.rs
@@ -62,6 +62,6 @@ fn main() {
 
     // TODO: can we (optionally?) produce a static copy? It'd probably be more
     // work, but would be easier for the end users.
-    println!("cargo:rustc-link-search=native={}", dst.display());
+    println!("cargo:rustc-link-search={}", dst.display());
     println!("cargo:rustc-link-lib=dylib=tcod");
 }


### PR DESCRIPTION
Really simple fix, changes "static" to "dylib" though, not sure why it was static because when I tried the output was a DLL.