### PR TITLE
Root creation blocking and consistency

### DIFF
--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -16,6 +16,12 @@ pub trait AsNative {
     unsafe fn as_native(&self) -> <Self as AsNative>::Output;
 }
 
+pub trait FromNative {
+    type Input;
+
+    unsafe fn from_native(input: <Self as FromNative>::Input) -> Self;
+}
+
 pub fn keycode_from_u32(input: u32) -> Option<KeyCode> {
     match input {
         0 => Some(KeyCode::NoKey),

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -1,4 +1,4 @@
-use bindings::ffi;
+use bindings::{AsNative, FromNative, ffi};
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -8,19 +8,23 @@ pub struct Color {
     pub b: u8,
 }
 
+impl AsNative for Color {
+    type Output = ffi::TCOD_color_t;
+
+    unsafe fn as_native(&self) -> ffi::TCOD_color_t {
+        ::std::mem::transmute(*self)
+    }
+}
+
+impl FromNative for Color {
+    type Input = ffi::TCOD_color_t;
+
+    unsafe fn from_native(input: ffi::TCOD_color_t) -> Color {
+        ::std::mem::transmute(input)
+    }
+}
+
 impl Color {
-    pub fn from_tcod_color_t(tcod_color_t: ffi::TCOD_color_t) -> Color {
-        unsafe {
-            ::std::mem::transmute(tcod_color_t)
-        }
-    }
-
-    pub fn to_color_t(self) -> ffi::TCOD_color_t {
-        unsafe {
-            ::std::mem::transmute(self)
-        }
-    }
-
     pub fn new(r: u8, g: u8, b: u8) -> Color {
         Color {
             r: r,
@@ -30,46 +34,46 @@ impl Color {
     }
 
     pub fn new_from_hsv(h: f32, s: f32, v: f32) -> Color {
-        let mut tcod_c = Color{r: 0, g: 0, b: 0}.to_color_t();
         unsafe {
-            ffi::TCOD_color_set_HSV(&mut tcod_c, h, s, v)
+            let mut tcod_c = Color{r: 0, g: 0, b: 0}.as_native();
+            ffi::TCOD_color_set_HSV(&mut tcod_c, h, s, v);
+            FromNative::from_native(tcod_c)
         }
-        Color::from_tcod_color_t(tcod_c)
     }
 
     pub fn multiply(self, other: Color) -> Color {
         unsafe {
-            Color::from_tcod_color_t(
-                ffi::TCOD_color_multiply(self.to_color_t(), other.to_color_t()))
+            FromNative::from_native(
+                ffi::TCOD_color_multiply(self.as_native(), other.as_native()))
         }
     }
 
     pub fn multiply_scalar(self, val: f32) -> Color {
         unsafe {
-            Color::from_tcod_color_t(
-                ffi::TCOD_color_multiply_scalar(self.to_color_t(), val))
+            FromNative::from_native(
+                ffi::TCOD_color_multiply_scalar(self.as_native(), val))
         }
     }
 
     pub fn add(self, other: Color) -> Color {
         unsafe {
-            Color::from_tcod_color_t(
-                ffi::TCOD_color_add(self.to_color_t(), other.to_color_t()))
+            FromNative::from_native(
+                ffi::TCOD_color_add(self.as_native(), other.as_native()))
         }
     }
 
     pub fn subtract(self, other: Color) -> Color {
         unsafe {
-            Color::from_tcod_color_t(
-                ffi::TCOD_color_subtract(self.to_color_t(), other.to_color_t()))
+            FromNative::from_native(
+                ffi::TCOD_color_subtract(self.as_native(), other.as_native()))
         }
     }
 
     pub fn lerp(self, to: Color, coefficient: f32) -> Color {
         unsafe {
-            Color::from_tcod_color_t(ffi::TCOD_color_lerp(self.to_color_t(),
-                                                          to.to_color_t(),
-                                                          coefficient))
+            FromNative::from_native(ffi::TCOD_color_lerp(self.as_native(),
+                                                         to.as_native(),
+                                                         coefficient))
         }
     }
 
@@ -78,25 +82,25 @@ impl Color {
         let mut s: f32 = 0.0;
         let mut v: f32 = 0.0;
         unsafe {
-            ffi::TCOD_color_get_HSV(self.to_color_t(), &mut h, &mut s, &mut v)
+            ffi::TCOD_color_get_HSV(self.as_native(), &mut h, &mut s, &mut v)
         }
         (h, s, v)
     }
 
     pub fn shift_hue(self, shift: f32) -> Color {
-        let mut c = self.to_color_t();
         unsafe {
+            let mut c = self.as_native();
             ffi::TCOD_color_shift_hue(&mut c, shift);
+            FromNative::from_native(c)
         }
-        Color::from_tcod_color_t(c)
     }
 
     pub fn scale_hsv(self, scale: f32, value: f32) -> Color {
-        let mut c = self.to_color_t();
         unsafe {
+            let mut c = self.as_native();
             ffi::TCOD_color_scale_HSV(&mut c, scale, value);
+            FromNative::from_native(c)
         }
-        Color::from_tcod_color_t(c)
     }
 }
 

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,5 +1,7 @@
 extern crate std;
 
+use std::marker::PhantomData;
+
 use bindings::ffi;
 use bindings::{AsNative, FromNative, c_bool, CString, keycode_from_u32};
 
@@ -28,7 +30,10 @@ impl Offscreen {
 
 }
 
-pub struct Root;
+pub struct Root {
+    // This is here to prevent the explicit creation of Root consoles.
+    _blocker: PhantomData<Root>
+}
 
 impl Root {
     pub fn initializer<'a>() -> RootInitializer<'a> {
@@ -241,7 +246,7 @@ impl<'a> RootInitializer<'a> {
                                         self.is_fullscreen as c_bool,
                                         self.console_renderer as u32);
         }
-        Root
+        Root { _blocker: PhantomData }
     }
 }
 

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,7 +1,7 @@
 extern crate std;
 
 use bindings::ffi;
-use bindings::{c_bool, CString, keycode_from_u32};
+use bindings::{AsNative, FromNative, c_bool, CString, keycode_from_u32};
 
 use colors::Color;
 use input::{Key, KeyPressFlags, KeyState};
@@ -68,14 +68,14 @@ impl Root {
 
     pub fn get_fading_color(&self) -> Color {
         unsafe {
-            Color::from_tcod_color_t(
+            FromNative::from_native(
                 ffi::TCOD_console_get_fading_color())
         }
     }
 
     pub fn set_fade(&mut self, fade: u8, fading_color: Color) {
         unsafe {
-            ffi::TCOD_console_set_fade(fade, fading_color.to_color_t());
+            ffi::TCOD_console_set_fade(fade, fading_color.as_native());
         }
     }
 
@@ -268,7 +268,7 @@ pub trait Console {
      
     fn set_key_color(&mut self, color: Color) {
         unsafe {
-            ffi::TCOD_console_set_key_color(self.con(), color.to_color_t());
+            ffi::TCOD_console_set_key_color(self.con(), color.as_native());
         }
     }
 
@@ -286,32 +286,32 @@ pub trait Console {
 
     fn set_default_background(&mut self, color: Color) {
         unsafe {
-            ffi::TCOD_console_set_default_background(self.con(), color.to_color_t());
+            ffi::TCOD_console_set_default_background(self.con(), color.as_native());
         }
     }
 
     fn set_default_foreground(&mut self, color: Color) {
         unsafe {
-            ffi::TCOD_console_set_default_foreground(self.con(), color.to_color_t());
+            ffi::TCOD_console_set_default_foreground(self.con(), color.as_native());
         }
     }
 
     fn console_set_key_color(&mut self, color: Color) {
         unsafe {
-            ffi::TCOD_console_set_key_color(self.con(), color.to_color_t());
+            ffi::TCOD_console_set_key_color(self.con(), color.as_native());
         }
     }
 
     fn get_char_background(&self, x: i32, y: i32) -> Color {
         unsafe {
-            Color::from_tcod_color_t(
+            FromNative::from_native(
                 ffi::TCOD_console_get_char_background(self.con(), x, y))
         }
     }
 
     fn get_char_foreground(&self, x: i32, y: i32) -> Color {
         unsafe {
-            Color::from_tcod_color_t(
+            FromNative::from_native(
                 ffi::TCOD_console_get_char_foreground(self.con(), x, y))
         }
     }
@@ -368,7 +368,7 @@ pub trait Console {
         unsafe {
             ffi::TCOD_console_set_char_background(self.con(),
                                                   x, y,
-                                                  color.to_color_t(),
+                                                  color.as_native(),
                                                   background_flag as u32)
         }
     }
@@ -378,7 +378,7 @@ pub trait Console {
         unsafe {
             ffi::TCOD_console_set_char_foreground(self.con(),
                                                   x, y,
-                                                  color.to_color_t());
+                                                  color.as_native());
         }
     }
 
@@ -400,8 +400,8 @@ pub trait Console {
         unsafe {
             ffi::TCOD_console_put_char_ex(self.con(),
                                           x, y, glyph as i32,
-                                          foreground.to_color_t(),
-                                          background.to_color_t());
+                                          foreground.as_native(),
+                                          background.as_native());
         }
     }
 
@@ -540,4 +540,3 @@ pub enum FontType {
     Default = 0,
     Greyscale = ffi::TCOD_FONT_TYPE_GREYSCALE as isize,
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #[macro_use] extern crate bitflags;
 
+pub use bindings::{AsNative, FromNative};
 pub use colors::Color;
 pub use console::{Console, RootInitializer, BackgroundFlag, Renderer, FontLayout, FontType, TextAlignment};
 pub use map::Map;


### PR DESCRIPTION
The blocking of the Root initializer with phantom types (mentioned in #144) was indeed the right idea. The way it is implemeted now generates no extra assembly (which is to be expected from `PhantomData`) but still blocks explicit instantiation of `Root` consoles.

The second part of this PR is making the API of the `Color` struct consistent with that of `Map's`. Since the `AsNative` trait was already approved, I implemented that on `Color` instead of a method directly on he struct. The `FromNative` trait is a natural addition that matches the style of `AsNative` quite nicely. 

This has the following advantages:
* no more potentially unsafe operations exposed as safe (in `Color`'s case `TCOD_color_t` was safe anyway, but it's better to be safe than sorry).
* consisteny between modules: if someone wants to use the underlying native type, they'll have to import `AsNative` or `FromNative`
* no change in any other place in the public API