### PR TITLE
Documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ authors = ["Tomas Sedovic <tomas@sedovic.cz>",
 name = "tcod"
 path = "src/lib.rs"
 
+# Workaround for cargo test giving linker errors for doctests
+doctest = false
+
 [dependencies]
 bitflags = "0.1"
 libc = "0.1.5"

--- a/src/console.rs
+++ b/src/console.rs
@@ -15,7 +15,7 @@
 //!
 //! let mut root = Root::initializer().init();
 //! let (width, height) = (80, 30);
-//! let mut offscreen = Offscren::new(width, height);
+//! let mut offscreen = Offscreen::new(width, height);
 //! ```
 //!
 //! A typical `tcod-rs` program's basic structure would look something like this:
@@ -49,7 +49,7 @@
 //!
 //! let mut root = RootConsole::initializer().init();
 //! let (width, height) = (80, 30);
-//! let mut offscreen = OffscrenConsole::new(width, height);
+//! let mut offscreen = OffscreenConsole::new(width, height);
 //! ```
 //! This applies to all the examples in the rest of the modules documentation.
 
@@ -167,7 +167,7 @@ impl Offscreen {
 /// rendering code:
 ///
 /// ```rust
-/// use tcod::console::Root;
+/// use tcod::console::{Console, Root};
 ///
 /// fn main() {
 ///     let mut root = Root::initializer().init();
@@ -387,7 +387,7 @@ struct FontDimensions(i32, i32);
 /// `RootInitializer` instance:
 ///
 /// ```rust
-/// use tcod::console::Root;
+/// use tcod::console::{Root, FontLayout, Renderer};
 ///
 /// fn main() {
 ///     let mut root = Root::initializer()
@@ -491,7 +491,7 @@ impl<'a> RootInitializer<'a> {
 /// Printing text with explicit alignment:
 ///
 /// ```rust
-/// use tcod::console::{Root, BackgroundFlag, TextAlignment};
+/// use tcod::console::{Console, Root, BackgroundFlag, TextAlignment};
 ///
 /// let mut root = Root::initializer().size(80, 50).init();
 /// 

--- a/src/console.rs
+++ b/src/console.rs
@@ -491,7 +491,9 @@ impl<'a> RootInitializer<'a> {
 /// Printing text with explicit alignment:
 ///
 /// ```rust
-/// let mut root = RootConsole::initializer().size(80, 50).init();
+/// use tcod::console::{Root, BackgroundFlag, TextAlignment};
+///
+/// let mut root = Root::initializer().size(80, 50).init();
 /// 
 /// root.print_ex(1, 1, BackgroundFlag::None, TextAlignment::Left,
 ///               "Text aligned to left.");
@@ -759,15 +761,15 @@ pub trait Console {
 ///
 /// ```rust
 /// use tcod::console as console;
-/// use tcod::console::{Root, Offscreen};
+/// use tcod::console::{Console, Root, Offscreen};
 ///
 /// fn main() {
 ///     let mut root = Root::initializer().init();
 ///
 ///     let mut direct = Offscreen::new(20, 20);
-///     let mut boxed_direct = Box::new(OffscreenConsole::new(20, 20));
-///     let mut trait_object: &Console = &OffscreenConsole::new(20, 20);
-///     let mut boxed_trait: Box<Console> = Box::new(OffscreenConsole::new(20, 20));
+///     let mut boxed_direct = Box::new(Offscreen::new(20, 20));
+///     let mut trait_object: &Console = &Offscreen::new(20, 20);
+///     let mut boxed_trait: Box<Console> = Box::new(Offscreen::new(20, 20));
 ///
 ///     console::blit(&direct, 0, 0, 20, 20, &mut root, 0, 0, 1.0, 1.0);
 ///     console::blit(&boxed_direct, 0, 0, 20, 20, &mut root, 20, 0, 1.0, 1.0);

--- a/src/console.rs
+++ b/src/console.rs
@@ -2,7 +2,7 @@
 //!
 //! It provides the necessary traits and types for working with the different console types, 
 //! including the [Console](./trait.Console.html) trait and the
-//! [Root](./struct.Root.html) and [Offscreen](./struct.Offscreen) console types.
+//! [Root](./struct.Root.html) and [Offscreen](./struct.Offscreen.html) console types.
 //! It's worth mentioning that only one `Root` console may exist at any given time, and it has to
 //! be initialized at the start of the program.
 //!
@@ -270,7 +270,7 @@ impl Root {
         }
     }
 
-    /// This function will wait for a keypress event from the user, returning the [KeyState](../input/enum.KeyState.html) 
+    /// This function will wait for a keypress event from the user, returning the [KeyState](../input/struct.KeyState.html) 
     /// that represents the event. If `flush` is true, all pending keypresses are flushed from the
     /// keyboard buffer. If false, it returns the first element from it.
     pub fn wait_for_keypress(&mut self, flush: bool) -> KeyState {
@@ -294,7 +294,7 @@ impl Root {
     }
 
     /// This function checks if the user pressed a key. It returns the
-    /// [KeyState](../input/enum.KeyState.html) representing the
+    /// [KeyState](../input/struct.KeyState.html) representing the
     /// event if they have, or `None` if they have not. 
     pub fn check_for_keypress(&self, status: KeyPressFlags) -> Option<KeyState> {
         let tcod_key = unsafe {
@@ -375,7 +375,7 @@ struct FontDimensions(i32, i32);
 /// * `font_dimensions`: the dimensions for the given bitmap font. This is automatically
 /// deduced from the font layout, only use this if you really need it (providing wrong values will
 /// ruin the font display).
-/// * `renderer`: sets the console renderer. See the [Renderer](./enum.Renderer) enum for the
+/// * `renderer`: sets the console renderer. See the [Renderer](./enum.Renderer.html) enum for the
 /// valid options.
 ///
 /// The initializer provides sane defaults even there are no options explicitly specified, but it
@@ -699,7 +699,7 @@ pub trait Console {
     }
 
     /// Prints the text at the specified location. The position of the `x` and `y` 
-    /// coordinates depend on the [TextAlignment](./enum.TextAlignment) set in the console:
+    /// coordinates depend on the [TextAlignment](./enum.TextAlignment.html) set in the console:
     ///
     /// * `TextAlignment::Left`: leftmost character of the string
     /// * `TextAlignment::Center`: center character of the sting

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,42 @@
+//! libtcod bindings for Rust
+//! 
+//! ## Description
+//! [libtcod a.k.a. "The Doryen Library"](http://roguecentral.org/doryen/libtcod/) is a 
+//! free, fast, portable and uncomplicated API for roguelike developpers providing lots of
+//! useful functions, such as:
+//!
+//! * Text-based graphics API
+//! * Colors
+//! * Keyboard and mouse input
+//! * Path finding
+//! * Field of View
+//! * Portability (works on Windows, Linux and OS X)
+//!
+//! For the full set of features see the [libtcod features page](http://roguecentral.org/doryen/libtcod/features/). 
+//! 
+//! All raw bindings are available via the `tcod-sys` crate, however the `tcod-rs` library aims to
+//! provide safe, Rust-style wrappers for most of `libtcod`. These wrappers are not yet complete,
+//! however.
+//!
+//! ### Features already implemented:
+//!
+//! * Colors
+//! * Console
+//! * Most of the System layer
+//! * Field of View
+//! * Map
+//! * Pathfinding
+//!
+//! ### Features that are not planned to be implemented:
+//! This are features that Rust already provides a good (and in most casese more idiomatic)
+//! solution for:
+//!
+//! * Filesystem utilities
+//! * Containers
+//! * Pseudorandom generators
+//! * Compression utilities
+//! 
+
 #[macro_use] extern crate bitflags;
 
 pub use bindings::{AsNative, FromNative};


### PR DESCRIPTION
Some work on the `console` module documentation. I tried to proofread it a few times, but might've missed a few mistakes here and there. Also, I don't know if you want to have excessive documentation in the main developement branch. If not, then just create a new branch and I'll resubmit the PR. The docs could use some more examples for the individual methods (printing, etc.), but this is all I had time for now.

Also I tried to mirror `libtcod`'s style of "comment even the most obviously named function", even though I kind of disagree with the concept: `set_fullscreen` is pretty self-explanatory for example. So if you'd prefer it that way, I'll happily remove the redundant comments.

EDIT: So, #80 is still not fixed in cargo upstream, so we cannot do doctests if we want to have a documentation with examples. After the `More example fixes` commit, the only errors I was getting were the linker ones, so the examples should not have any bugs in them.