### PR TITLE
Started implementing missing features

### DIFF
--- a/examples/print_macros.rs
+++ b/examples/print_macros.rs
@@ -1,0 +1,28 @@
+#[macro_use]
+extern crate tcod;
+
+use tcod::{Console, RootConsole, BackgroundFlag, TextAlignment};
+
+fn main() {
+    let mut root = RootConsole::initializer().size(80, 50).title("Displaying text").init();
+
+    // No optional parameters
+    tcod_print!(root, At(1, 1), "Any text params may be {}", "formatted with println! formatting");
+
+    // One optional parameter
+    tcod_print!(root, At(1, 3), Wrap(6, 2), "Simple wrap"); 
+    tcod_print!(root, At(1, 6), Bg(BackgroundFlag::None), "No background flag"); 
+    tcod_print!(root, At(75, 8), Align(TextAlignment::Right), "Right align"); 
+
+
+    // Two optional parameters. The optional parameters may be given in any order
+    tcod_print!(root, At(1, 10), Wrap(6, 2), Bg(BackgroundFlag::None), "Bg and wrap"); 
+    tcod_print!(root, At(70, 12), Align(TextAlignment::Right), Wrap(6, 3), "Align and wrap"); 
+   
+    // Three optional parameters
+    tcod_print!(root, At(40, 25), Wrap(10, 10), Bg(BackgroundFlag::None), Align(TextAlignment::Center),
+                "This text is printed with every optional parameter, format: {} {}", "string", 1);
+
+    root.flush();
+    root.wait_for_keypress(true);
+}

--- a/src/console.rs
+++ b/src/console.rs
@@ -341,8 +341,6 @@ impl Root {
         }
     }
 
-
-
     fn set_custom_font(font_path: &std::path::Path,
                        font_layout: FontLayout,
                        font_type: FontType,
@@ -764,7 +762,6 @@ pub trait Console {
                                             c_text.as_ptr());
         }
     }
-
 }
 
 /// Blits the contents of one console onto an other

--- a/src/console.rs
+++ b/src/console.rs
@@ -341,6 +341,8 @@ impl Root {
         }
     }
 
+
+
     fn set_custom_font(font_path: &std::path::Path,
                        font_layout: FontLayout,
                        font_type: FontType,
@@ -714,6 +716,20 @@ pub trait Console {
         }
     }
 
+    /// Prints the text at the specified location in a rectangular area with
+    /// the dimensions: (width; height). If the text is longer than the width the
+    /// newlines will be inserted.
+    fn print_rect(&mut self, 
+                  x: i32, y: i32, 
+                  width: i32, height: i32,
+                  text: &str) {
+        assert!(x >= 0 && y >= 0);
+        unsafe {
+            let c_text = CString::new(text.as_bytes()).unwrap();
+            ffi::TCOD_console_print_rect(self.con(), x, y, width, height, c_text.as_ptr());
+        }
+    }
+
     /// Prints the text at the specified location with an explicit
     /// [BackgroundFlag](./enum.BackgroundFlag.html) and
     /// [TextAlignment](./enum.TextAlignment.html).
@@ -732,6 +748,23 @@ pub trait Console {
                                        c_text.as_ptr());
         }
     }
+
+    /// Combines the functions of `print_ex` and `print_rect`
+    fn print_rect_ex(&mut self, 
+                     x: i32, y: i32, 
+                     width: i32, height: i32,
+                     background_flag: BackgroundFlag,
+                     alignment: TextAlignment,
+                     text: &str) {
+        assert!(x >= 0 && y >= 0);
+        unsafe {
+            let c_text = CString::new(text.as_bytes()).unwrap();
+            ffi::TCOD_console_print_rect_ex(self.con(), x, y, width, height,
+                                            background_flag as u32, alignment as u32, 
+                                            c_text.as_ptr());
+        }
+    }
+
 }
 
 /// Blits the contents of one console onto an other

--- a/src/console_macros.rs
+++ b/src/console_macros.rs
@@ -1,0 +1,106 @@
+#[macro_export]
+macro_rules! tcod_print {
+    // ABW
+    ($con: expr, At($x: expr, $y: expr), Align($alignment: expr), 
+     Bg($bg: expr), Wrap($width: expr, $height: expr), $($arg: tt)*) => (
+        $con.print_rect_ex($x, $y, $width, $height, $bg, $alignment, format!($($arg)*).as_ref());
+    );
+
+    // AWB
+    ($con: expr, At($x: expr, $y: expr), Align($alignment: expr),
+     Wrap($width: expr, $height: expr), Bg($bg: expr), $($arg: tt)*) => (
+        $con.print_rect_ex($x, $y, $width, $height, $bg, $alignment, format!($($arg)*).as_ref());
+    );
+    
+    // BAW
+    ($con: expr, At($x: expr, $y: expr), Bg($bg: expr), 
+     Align($alignment: expr), Wrap($width: expr, $height: expr), $($arg: tt)*) => (
+        $con.print_rect_ex($x, $y, $width, $height, $bg, $alignment, format!($($arg)*).as_ref());
+    );
+    
+    // BWA
+    ($con: expr, At($x: expr, $y: expr), Bg($bg: expr), 
+     Wrap($width: expr, $height: expr), Align($alignment: expr), $($arg: tt)*) => (
+        $con.print_rect_ex($x, $y, $width, $height, $bg, $alignment, format!($($arg)*).as_ref());
+    );
+     
+    // WAB
+    ($con: expr, At($x: expr, $y: expr), Wrap($width: expr, $height: expr), 
+     Align($alignment: expr), Bg($bg: expr), $($arg: tt)*) => (
+        $con.print_rect_ex($x, $y, $width, $height, $bg, $alignment, format!($($arg)*).as_ref());
+    );
+    
+    // WBA
+    ($con: expr, At($x: expr, $y: expr), Wrap($width: expr, $height: expr), 
+     Bg($bg: expr), Align($alignment: expr), $($arg: tt)*) => (
+        $con.print_rect_ex($x, $y, $width, $height, $bg, $alignment, format!($($arg)*).as_ref());
+    );
+    
+    // AB
+    ($con: expr, At($x: expr, $y: expr), Align($bg: expr), Bg($alignment: expr), $($arg: tt)*) => (
+        $con.print_ex($x, $y, $bg, $alignment, format!($($arg)*).as_ref());
+    );    
+     
+    // AW
+    ($con: expr, At($x: expr, $y: expr), Align($alignment: expr), Wrap($width: expr, $height: expr), $($arg: tt)*) => (
+        {
+            let bg = $con.get_background_flag();
+            $con.print_rect_ex($x, $y, $width, $height, bg, $alignment, format!($($arg)*).as_ref());
+        }
+    );
+   
+    // BA
+    ($con: expr, At($x: expr, $y: expr), Bg($bg: expr), Align($alignment: expr), $($arg: tt)*) => (
+        $con.print_ex($x, $y, $bg, $alignment, format!($($arg)*).as_ref());
+    );
+     
+    // BW
+    ($con: expr, At($x: expr, $y: expr), Bg($bg: expr), Wrap($width: expr, $height: expr), $($arg: tt)*) => (
+        {
+            let alignment = $con.get_alignment();
+            $con.print_rect_ex($x, $y, $width, $height, $bg, alignment, format!($($arg)*).as_ref());
+        }
+    );
+    
+    // WA
+    ($con: expr, At($x: expr, $y: expr), Wrap($width: expr, $height: expr), Align($alignment: expr), $($arg: tt)*) => (
+        {
+            let bg = $con.get_background_flag();
+            $con.print_rect_ex($x, $y, $width, $height, bg, $alignment, format!($($arg)*).as_ref());
+        }
+    );
+    
+    // WB
+    ($con: expr, At($x: expr, $y: expr), Wrap($width: expr, $height: expr), Bg($bg: expr), $($arg: tt)*) => (
+        {
+            let alignment = $con.get_alignment();
+            $con.print_rect_ex($x, $y, $width, $height, $bg, alignment, format!($($arg)*).as_ref());
+        }
+    );
+    
+    // A
+    ($con: expr, At($x: expr, $y: expr), Align($alignment: expr), $($arg: tt)*) => (
+        {
+            let bg = $con.get_background_flag();
+            $con.print_ex($x, $y, bg, $alignment, format!($($arg)*).as_ref());
+        }
+    );
+    
+    // B
+    ($con: expr, At($x: expr, $y: expr), Bg($bg: expr), $($arg: tt)*) => (
+        {
+            let alignment = $con.get_alignment();
+            $con.print_ex($x, $y, $bg, alignment, format!($($arg)*).as_ref());
+        }
+    );
+
+    // W
+    ($con: expr, At($x: expr, $y: expr), Wrap($width: expr, $height: expr), $($arg: tt)*) => (
+        $con.print_rect($x, $y, $width, $height, format!($($arg)*).as_ref());
+    );
+    
+    // None
+    ($con: expr, At($x: expr, $y: expr), $($arg: tt)*) => (
+        $con.print($x, $y, format!($($arg)*).as_ref());
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub mod pathfinding;
 pub mod system;
 
 mod bindings;
-
+mod console_macros;
 
 pub type RootConsole = console::Root; 
 pub type OffscreenConsole = console::Offscreen;


### PR DESCRIPTION
I'm not too attached to the macros part, I pretty much just wanted to get a second opinion, and I thought I would put it in the PR. I think it's nicer to use then the miriad of printing functions in `libtcod` and it also has the advantage of accepting Rust-style format strings. 

The thing I dislike about it is that the printing modifiers come before the string we want to print. Because of the macro definition rules there's only one solution to this problem: wrapping the `$($arg: tt)*` part in some kind of parentheses, which is also not ideal.

I'll do [these](http://doryen.eptalys.net/data/libtcod/doc/1.5.2/html2/console_advanced.html) next, any ideas for a nice API? I'm thinking enums with variants that take `i32`'s as their parameters and a single `Console::draw` method. The problem with this is that not all functions have the `clear` flag. Any way to easily get around this? Just add a bool member to the enumu variants?