### PR TITLE
Use `AsRef<Path>` for fns that take a fs path

### DIFF
--- a/examples/roguelike-tutorial-1.rs
+++ b/examples/roguelike-tutorial-1.rs
@@ -6,7 +6,6 @@
 
 extern crate tcod;
 
-use std::path::Path;
 use tcod::console::{Root, Console, FontLayout, FontType, BackgroundFlag};
 use tcod::colors;
 use tcod::input::Key::Special;
@@ -43,7 +42,7 @@ fn handle_keys(root: &mut Root, player_x: &mut i32, player_y: &mut i32) -> bool 
 
 fn main() {
     let mut root = Root::initializer()
-        .font(&Path::new("arial10x10.png"), FontLayout::Tcod)
+        .font("arial10x10.png", FontLayout::Tcod)
         .font_type(FontType::Greyscale)
         .size(SCREEN_WIDTH, SCREEN_HEIGHT)
         .title("Rust/libtcod tutorial")

--- a/examples/roguelike-tutorial-2.rs
+++ b/examples/roguelike-tutorial-2.rs
@@ -6,7 +6,6 @@
 
 extern crate tcod;
 
-use std::path::Path;
 use tcod::console::{Root, Offscreen, Console, FontLayout, FontType, BackgroundFlag};
 use tcod::colors::{self, Color};
 use tcod::input::Key::Special;
@@ -133,7 +132,7 @@ fn handle_keys(root: &mut Root, player: &mut Object, map: &Map) -> bool {
 
 fn main() {
     let mut root = Root::initializer()
-        .font(&Path::new("arial10x10.png"), FontLayout::Tcod)
+        .font("arial10x10.png", FontLayout::Tcod)
         .font_type(FontType::Greyscale)
         .size(SCREEN_WIDTH, SCREEN_HEIGHT)
         .title("Rust/libtcod tutorial")

--- a/src/console.rs
+++ b/src/console.rs
@@ -926,3 +926,35 @@ pub enum FontType {
     Default = 0,
     Greyscale = ffi::TCOD_FONT_TYPE_GREYSCALE as isize,
 }
+
+
+
+#[cfg(test)]
+mod test {
+    use std::path::Path;
+    use super::Root;
+    use super::FontLayout::AsciiInCol;
+
+    #[test]
+    fn test_custom_font_as_static_str() {
+        Root::initializer().font("terminal.png", AsciiInCol);
+    }
+
+    #[test]
+    fn test_custom_font_as_path() {
+        Root::initializer().font(Path::new("terminal.png"), AsciiInCol);
+
+    }
+
+    #[test]
+    fn test_custom_font_as_string() {
+        Root::initializer().font("terminal.png".to_owned(), AsciiInCol);
+    }
+
+    #[test]
+    fn test_custom_font_as_str() {
+        let string = "terminal.png".to_owned();
+        let s: &str = &string;
+        Root::initializer().font(s, AsciiInCol);
+    }
+}

--- a/src/console.rs
+++ b/src/console.rs
@@ -370,7 +370,11 @@ struct FontDimensions(i32, i32);
 /// * `title`: the main window's title
 /// * `fullscreen`: determines if the main window will start in fullscreen mode
 /// * `font`: selects a bitmap font and sets its layout. See [FontLayout](./enum.FontLayout.html)
-/// for the possible layouts.
+/// for the possible layouts. The `path` argument can be a
+/// [`str`](http://doc.rust-lang.org/std/primitive.str.html),
+/// [`Path`](http://doc.rust-lang.org/std/path/struct.Path.html),
+/// [`String`](http://doc.rust-lang.org/std/string/struct.String.html) or anything else that
+/// implements [`AsRef<Path>`](http://doc.rust-lang.org/std/convert/trait.AsRef.html).
 /// * `font_type`: only use this if you want to use a greyscale font. See
 /// [FontType](./enum.FontType.html) for the possible values.
 /// * `font_dimensions`: the dimensions for the given bitmap font. This is automatically
@@ -388,7 +392,6 @@ struct FontDimensions(i32, i32);
 /// `RootInitializer` instance:
 ///
 /// ```rust
-/// use std::path::Path;
 /// use tcod::console::{Root, FontLayout, Renderer};
 ///
 /// fn main() {
@@ -396,7 +399,7 @@ struct FontDimensions(i32, i32);
 ///         .size(80, 20)
 ///         .title("Example")
 ///         .fullscreen(true)
-///         .font(&Path::new("terminal.png"), FontLayout::AsciiInCol)
+///         .font("terminal.png", FontLayout::AsciiInCol)
 ///         .renderer(Renderer::GLSL)
 ///         .init();
 /// }
@@ -406,7 +409,7 @@ pub struct RootInitializer<'a> {
     height: i32,
     title: &'a str,
     is_fullscreen: bool,
-    font_path: &'a Path,
+    font_path: Box<AsRef<Path>+'a>,
     font_layout: FontLayout,
     font_type: FontType,
     font_dimension: FontDimensions,
@@ -420,7 +423,7 @@ impl<'a> RootInitializer<'a> {
             height: 25,
             title: "Main Window",
             is_fullscreen: false,
-            font_path: &Path::new("terminal.png"),
+            font_path: Box::new("terminal.png"),
             font_layout: FontLayout::AsciiInCol,
             font_type: FontType::Default,
             font_dimension: FontDimensions(0, 0),
@@ -444,8 +447,8 @@ impl<'a> RootInitializer<'a> {
         self
     }
 
-    pub fn font(&mut self, path: &'a Path, font_layout: FontLayout) -> &mut RootInitializer<'a> {
-        self.font_path = path;
+    pub fn font<P: AsRef<Path>+'a>(&mut self, path: P, font_layout: FontLayout) -> &mut RootInitializer<'a> {
+        self.font_path = Box::new(path);
         self.font_layout = font_layout;
         self
     }
@@ -470,7 +473,7 @@ impl<'a> RootInitializer<'a> {
 
         match self.font_dimension {
             FontDimensions(horizontal, vertical) => {
-                Root::set_custom_font(self.font_path,
+                Root::set_custom_font(self.font_path.as_ref(),
                                       self.font_layout, self.font_type,
                                       horizontal, vertical)
             }

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,6 +1,7 @@
 extern crate std;
 extern crate time;
 
+use std::path::Path;
 use bindings::ffi;
 
 use self::time::Duration;
@@ -40,8 +41,8 @@ pub fn get_elapsed_time() -> Duration {
     return Duration::milliseconds(ms as i64)
 }
 
-pub fn save_screenshot(path: &std::path::Path) {
-    let filename = path.to_str().unwrap();
+pub fn save_screenshot<P: AsRef<Path>>(path: P) {
+    let filename = path.as_ref().to_str().unwrap();
     let c_path = std::ffi::CString::new(filename).unwrap();
     unsafe {
         ffi::TCOD_sys_save_screenshot(c_path.as_ptr());


### PR DESCRIPTION
This let's us pass a str and Path to `RootInitializer::font` for example.

We get back the ergonomics of accepting `&str`, but if a user has a Path, they
can still just pass it in.

The situation here is complicated by the fact that we have to store the value in
the `RootInitializer` struct, which can be done either by taking a Reference to
`AsPath` or by saving it in a Box.

I've opted for the latter since the struct is short-lived and it will only be
done once. Otherwise, we'd have to put the str and Path behind an reference:

Root::initializer().font("terminal.png").init();

vs.

Root::initializer().font(&"terminal.png").init();