### PR TITLE
Unicode - Ascii printing dispatch

### DIFF
--- a/examples/blit.rs
+++ b/examples/blit.rs
@@ -16,6 +16,7 @@ fn main() {
     let mut trait_object: &Console = &OffscreenConsole::new(20, 20);
     let mut boxed_trait: Box<Console> = Box::new(OffscreenConsole::new(20, 20));
 
+
     root.set_default_background(colors::DARKEST_GREEN);
 
     direct.set_default_background(colors::RED);

--- a/examples/blit.rs
+++ b/examples/blit.rs
@@ -16,6 +16,7 @@ fn main() {
     let mut trait_object: &Console = &OffscreenConsole::new(20, 20);
     let mut boxed_trait: Box<Console> = Box::new(OffscreenConsole::new(20, 20));
 
+    trait_object.obj_unsafe(&9);
 
     root.set_default_background(colors::DARKEST_GREEN);
 

--- a/examples/blit.rs
+++ b/examples/blit.rs
@@ -16,8 +16,6 @@ fn main() {
     let mut trait_object: &Console = &OffscreenConsole::new(20, 20);
     let mut boxed_trait: Box<Console> = Box::new(OffscreenConsole::new(20, 20));
 
-    trait_object.obj_unsafe(&9);
-
     root.set_default_background(colors::DARKEST_GREEN);
 
     direct.set_default_background(colors::RED);

--- a/examples/roguelike-tutorial-2.rs
+++ b/examples/roguelike-tutorial-2.rs
@@ -51,12 +51,12 @@ impl Object {
         }
     }
 
-    pub fn draw(&self, con: &mut Console) {
+    pub fn draw(&self, mut con: &Console) {
         con.set_default_foreground(self.color);
         con.put_char(self.x, self.y, self.char, BackgroundFlag::None);
     }
 
-    pub fn clear(&self, con: &mut Console) {
+    pub fn clear(&self, mut con: &Console) {
         con.put_char(self.x, self.y, ' ', BackgroundFlag::None);
     }
 }

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -9,10 +9,13 @@ fn main() {
                   "Text aligned to left.");
     root.print_ex(78, 1, BackgroundFlag::None, TextAlignment::Right,
                   "Text aligned to right.");
+    root.print_ex(40, 10, BackgroundFlag::None, TextAlignment::Center,
+                  b"ASCII text!" as &[u8]);
     root.print_ex(40, 15, BackgroundFlag::None, TextAlignment::Center,
                   "And this bit of text is centered.");
     root.print_ex(40, 19, BackgroundFlag::None, TextAlignment::Center,
                   "Press any key to quit.");
+
     root.flush();
     root.wait_for_keypress(true);
 }

--- a/src/console.rs
+++ b/src/console.rs
@@ -828,6 +828,10 @@ pub trait Console {
                                           clear as c_bool, background_flag as u32, c_title);
         }
     }
+
+    fn obj_unsafe<T>(&mut self, _: &T) where Self: Sized {
+
+    }
 }
 
 /// Blits the contents of one console onto an other
@@ -895,13 +899,13 @@ pub fn blit<T, U>(source_console: &T,
     }
 }
 
-impl<'a> Console for &'a Console {
-    unsafe fn con(&self) -> ffi::TCOD_console_t {
-        (*self).con()
-    }
+impl<'a, T: Console + ?Sized> Console for &'a T  {
+   unsafe fn con(&self) -> ffi::TCOD_console_t {
+       (*self).con()
+   }
 }
 
-impl Console for Box<Console> {
+impl<T: Console + ?Sized> Console for Box<T> {
     unsafe fn con(&self) -> ffi::TCOD_console_t {
         (**self).con()
     }
@@ -913,21 +917,9 @@ impl Console for Root {
     }
 }
 
-impl Console for Box<Root> {
-    unsafe fn con(&self) -> ffi::TCOD_console_t {
-        (**self).con()
-    }
-}
-
 impl Console for Offscreen {
     unsafe fn con(&self) -> ffi::TCOD_console_t {
         self.con
-    }
-}
-
-impl Console for Box<Offscreen> {
-    unsafe fn con(&self) -> ffi::TCOD_console_t {
-        (**self).con()
     }
 }
 

--- a/src/console.rs
+++ b/src/console.rs
@@ -490,6 +490,13 @@ impl<'a> RootInitializer<'a> {
     }
 }
 
+pub trait UnicodeString {}
+pub trait AsciiString {}
+
+impl UnicodeString for String {}
+impl<'a> UnicodeString for &'a str {}
+impl<'a> AsciiString for &'a [u8] {}
+
 pub trait TcodString {
     fn print(&self, con: &mut Console, x: i32, y: i32);
     fn print_rect(&self, con: &mut Console, x: i32, y: i32, width: i32, height: i32);
@@ -498,24 +505,24 @@ pub trait TcodString {
                      background_flag: BackgroundFlag, alignment: TextAlignment);
 }
 
-impl<'a> TcodString for &'a str { 
+impl<T> TcodString for T where T: AsRef<str> + UnicodeString { 
     fn print(&self, con: &mut Console, x: i32, y: i32) {
         unsafe {
-            let c_text = self.chars().collect::<Vec<_>>();
+            let c_text = self.as_ref().chars().collect::<Vec<_>>();
             ffi::TCOD_console_print_utf(con.con(), x, y, c_text.as_ptr() as *const i32);
         }
     }
 
     fn print_rect(&self, con: &mut Console, x: i32, y: i32, width: i32, height: i32) {
         unsafe {
-            let c_text = self.chars().collect::<Vec<_>>();
+            let c_text = self.as_ref().chars().collect::<Vec<_>>();
             ffi::TCOD_console_print_rect_utf(con.con(), x, y, width, height, c_text.as_ptr() as *const i32);
         }
     }
 
     fn print_ex(&self, con: &mut Console, x: i32, y: i32, background_flag: BackgroundFlag, alignment: TextAlignment) {
         unsafe {
-            let c_text = self.chars().collect::<Vec<_>>();
+            let c_text = self.as_ref().chars().collect::<Vec<_>>();
             ffi::TCOD_console_print_ex_utf(con.con(),
                                            x, y,
                                            background_flag as u32,
@@ -527,30 +534,11 @@ impl<'a> TcodString for &'a str {
     fn print_rect_ex(&self, con: &mut Console, x: i32, y: i32, width: i32, height: i32, 
                      background_flag: BackgroundFlag, alignment: TextAlignment) {
         unsafe {
-            let c_text = self.chars().collect::<Vec<_>>();
+            let c_text = self.as_ref().chars().collect::<Vec<_>>();
             ffi::TCOD_console_print_rect_ex_utf(con.con(), x, y, width, height,
                                                 background_flag as u32, alignment as u32,
                                                 c_text.as_ptr() as *const i32);
         }
-    }
-}
-
-impl TcodString for String {
-    fn print(&self, con: &mut Console, x: i32, y: i32) {
-        AsRef::<str>::as_ref(self).print(con, x, y);
-    }
-
-    fn print_rect(&self, con: &mut Console, x: i32, y: i32, width: i32, height: i32) {
-        AsRef::<str>::as_ref(self).print_rect(con, x, y, width, height);
-    }
-
-    fn print_ex(&self, con: &mut Console, x: i32, y: i32, background_flag: BackgroundFlag, alignment: TextAlignment) {
-        AsRef::<str>::as_ref(self).print_ex(con, x, y, background_flag, alignment);
-    }
-
-    fn print_rect_ex(&self, con: &mut Console, x: i32, y: i32, width: i32, height: i32,
-                     background_flag: BackgroundFlag, alignment: TextAlignment) {
-        AsRef::<str>::as_ref(self).print_rect_ex(con, x, y, width, height, background_flag, alignment);
     }
 }
 

--- a/src/console.rs
+++ b/src/console.rs
@@ -826,7 +826,7 @@ pub trait Console {
     /// Updates every propert of the given cell using explicit colors for the
     /// background and foreground.
     fn put_char_ex<T>(&mut self,
-                      x: i32, y: i32, glyph: char,
+                      x: i32, y: i32, glyph: T,
                       foreground: Color, background: Color) where Self: Sized, T: TcodChar {
         assert!(x >= 0 && y >= 0);
         glyph.put_ex(self, x, y, foreground, background);
@@ -1013,7 +1013,7 @@ pub fn blit<T, U>(source_console: &T,
 
 impl<'a, T: Console + ?Sized> Console for &'a T  {
    unsafe fn con(&self) -> ffi::TCOD_console_t {
-       (*self).con()
+       (**self).con()
    }
 }
 

--- a/src/console_macros.rs
+++ b/src/console_macros.rs
@@ -3,62 +3,62 @@ macro_rules! tcod_print {
     // ABW
     ($con: expr, At($x: expr, $y: expr), Align($alignment: expr),
      Bg($bg: expr), Wrap($width: expr, $height: expr), $($arg: tt)*) => (
-        $con.print_rect_ex($x, $y, $width, $height, $bg, $alignment, format!($($arg)*).as_ref());
+        $con.print_rect_ex($x, $y, $width, $height, $bg, $alignment, format!($($arg)*));
     );
 
     // AWB
     ($con: expr, At($x: expr, $y: expr), Align($alignment: expr),
      Wrap($width: expr, $height: expr), Bg($bg: expr), $($arg: tt)*) => (
-        $con.print_rect_ex($x, $y, $width, $height, $bg, $alignment, format!($($arg)*).as_ref());
+        $con.print_rect_ex($x, $y, $width, $height, $bg, $alignment, format!($($arg)*));
     );
 
     // BAW
     ($con: expr, At($x: expr, $y: expr), Bg($bg: expr),
      Align($alignment: expr), Wrap($width: expr, $height: expr), $($arg: tt)*) => (
-        $con.print_rect_ex($x, $y, $width, $height, $bg, $alignment, format!($($arg)*).as_ref());
+        $con.print_rect_ex($x, $y, $width, $height, $bg, $alignment, format!($($arg)*));
     );
 
     // BWA
     ($con: expr, At($x: expr, $y: expr), Bg($bg: expr),
      Wrap($width: expr, $height: expr), Align($alignment: expr), $($arg: tt)*) => (
-        $con.print_rect_ex($x, $y, $width, $height, $bg, $alignment, format!($($arg)*).as_ref());
+        $con.print_rect_ex($x, $y, $width, $height, $bg, $alignment, format!($($arg)*));
     );
 
     // WAB
     ($con: expr, At($x: expr, $y: expr), Wrap($width: expr, $height: expr),
      Align($alignment: expr), Bg($bg: expr), $($arg: tt)*) => (
-        $con.print_rect_ex($x, $y, $width, $height, $bg, $alignment, format!($($arg)*).as_ref());
+        $con.print_rect_ex($x, $y, $width, $height, $bg, $alignment, format!($($arg)*));
     );
 
     // WBA
     ($con: expr, At($x: expr, $y: expr), Wrap($width: expr, $height: expr),
      Bg($bg: expr), Align($alignment: expr), $($arg: tt)*) => (
-        $con.print_rect_ex($x, $y, $width, $height, $bg, $alignment, format!($($arg)*).as_ref());
+        $con.print_rect_ex($x, $y, $width, $height, $bg, $alignment, format!($($arg)*));
     );
 
     // AB
     ($con: expr, At($x: expr, $y: expr), Align($bg: expr), Bg($alignment: expr), $($arg: tt)*) => (
-        $con.print_ex($x, $y, $bg, $alignment, format!($($arg)*).as_ref());
+        $con.print_ex($x, $y, $bg, $alignment, format!($($arg)*));
     );
 
     // AW
     ($con: expr, At($x: expr, $y: expr), Align($alignment: expr), Wrap($width: expr, $height: expr), $($arg: tt)*) => (
         {
             let bg = $con.get_background_flag();
-            $con.print_rect_ex($x, $y, $width, $height, bg, $alignment, format!($($arg)*).as_ref());
+            $con.print_rect_ex($x, $y, $width, $height, bg, $alignment, format!($($arg)*));
         }
     );
 
     // BA
     ($con: expr, At($x: expr, $y: expr), Bg($bg: expr), Align($alignment: expr), $($arg: tt)*) => (
-        $con.print_ex($x, $y, $bg, $alignment, format!($($arg)*).as_ref());
+        $con.print_ex($x, $y, $bg, $alignment, format!($($arg)*));
     );
 
     // BW
     ($con: expr, At($x: expr, $y: expr), Bg($bg: expr), Wrap($width: expr, $height: expr), $($arg: tt)*) => (
         {
             let alignment = $con.get_alignment();
-            $con.print_rect_ex($x, $y, $width, $height, $bg, alignment, format!($($arg)*).as_ref());
+            $con.print_rect_ex($x, $y, $width, $height, $bg, alignment, format!($($arg)*));
         }
     );
 
@@ -66,7 +66,7 @@ macro_rules! tcod_print {
     ($con: expr, At($x: expr, $y: expr), Wrap($width: expr, $height: expr), Align($alignment: expr), $($arg: tt)*) => (
         {
             let bg = $con.get_background_flag();
-            $con.print_rect_ex($x, $y, $width, $height, bg, $alignment, format!($($arg)*).as_ref());
+            $con.print_rect_ex($x, $y, $width, $height, bg, $alignment, format!($($arg)*));
         }
     );
 
@@ -74,7 +74,7 @@ macro_rules! tcod_print {
     ($con: expr, At($x: expr, $y: expr), Wrap($width: expr, $height: expr), Bg($bg: expr), $($arg: tt)*) => (
         {
             let alignment = $con.get_alignment();
-            $con.print_rect_ex($x, $y, $width, $height, $bg, alignment, format!($($arg)*).as_ref());
+            $con.print_rect_ex($x, $y, $width, $height, $bg, alignment, format!($($arg)*));
         }
     );
 
@@ -82,7 +82,7 @@ macro_rules! tcod_print {
     ($con: expr, At($x: expr, $y: expr), Align($alignment: expr), $($arg: tt)*) => (
         {
             let bg = $con.get_background_flag();
-            $con.print_ex($x, $y, bg, $alignment, format!($($arg)*).as_ref());
+            $con.print_ex($x, $y, bg, $alignment, format!($($arg)*));
         }
     );
 
@@ -90,17 +90,17 @@ macro_rules! tcod_print {
     ($con: expr, At($x: expr, $y: expr), Bg($bg: expr), $($arg: tt)*) => (
         {
             let alignment = $con.get_alignment();
-            $con.print_ex($x, $y, $bg, alignment, format!($($arg)*).as_ref());
+            $con.print_ex($x, $y, $bg, alignment, format!($($arg)*));
         }
     );
 
     // W
     ($con: expr, At($x: expr, $y: expr), Wrap($width: expr, $height: expr), $($arg: tt)*) => (
-        $con.print_rect($x, $y, $width, $height, format!($($arg)*).as_ref());
+        $con.print_rect($x, $y, $width, $height, format!($($arg)*));
     );
 
     // None
     ($con: expr, At($x: expr, $y: expr), $($arg: tt)*) => (
-        $con.print($x, $y, format!($($arg)*).as_ref());
+        $con.print($x, $y, format!($($arg)*));
     );
 }


### PR DESCRIPTION
Please don't merge this yet, I'm sending this mainly because I'd like some feedback on the API and whatnot. So as it stands, this succesfully dispatches `&str` and `String` to the Unicode, and `&[u8]` to the ASCII printing functions. 

Problems
-------------
1. The type-by-type implementation is tedious, but I haven't found a way to make a nice blanket implementation. Since there are no negative trait bounds I don't see a simple way around this problem. If anyone has any ideas, feel free to post them.
2. Is there a more efficient way to convert a `&str` to a `*const i32`? The current method works, but allocating a new `Vec` for each string seems like a bit of an overkill. (Also do we have to explicitly push a `\0` at the end of these `Vecs`?).
3. I can't figure out a way to simply accept a byte literal in the print functions: I have to add an `as &[u8]` for it to work. 
4. There are two possible API designs:

  * **Take the text we want to print by value:** this makes it nicer to directly print `&str` values (no need for an explicit `&`), but will move `String` values. Note that this is equivalent to the current implementation, since we didn't support passing `Strings` earlier. The only problem is that you cannot simple do an `as_ref` on the `String`, since it has both `AsRef<str>` and `AsRef<[u8]>` implemented, leading to an ambigous call... On this note, I really wish Rust would differentiate between the `&str` and `&[u8]` representations. 
  * **Take it by reference:** this makes it more annoying to print `&str` (and so string literals), since you have to explicitly add a `&` to every one of them, but has the advantage of not moving `String` values.

Alternatives:
-----------------
1. We could just drop the whole UTF thing, assert on [AsciiExt::is_ascii()](https://doc.rust-lang.org/nightly/std/ascii/trait.AsciiExt.html#method.is_ascii) and keep doing things as they are now. If I understand correctly this is pretty much what the Python bindings do (the `libtcod` docs say that UTF is not supported with them).

2. We could dispatch at runtime based on `is_ascii`, so we only do the `&[u8]` to UTF conversion when it's absolutely needed. This is probably the most flexible solution, but loses out in raw performance with ASCII strings. The thing is that the implementation in this PR heavily favors the use of UTF strings, which will have worse performance (due to the string-by-string `Vec` allocations).

3. Have `libtcod` style `_utf` functions. I don't really like this option. It doesn't make for a very user-friendly API: we have these explicit functions when we could've dispatched them either at runtime or compile time. The only advantage is being able to use `&str` in both functions (not possible with this PR, possible with `Alt #2`).

#### Opinion
After giving it some thought, I actually think that `Alternative #2` is probably the best option here. It makes it easy to use the interface correctly. The printing of ASCII strings is probably the most common use-case, so making it easy should be a top priority. With the runtime dispatch we add a single `if` overhead, but retain correctness (in the UTF case we would've had to do the conversions anyway). This PR was actually pretty fun to experiment with (and provided some great experience for my hobby project!), but it's being too tricky for a library API in my opinion. If there's a decision I'd be happy to implement whatever it ends up being.

cc @P1start since they seemed to be interested in the whole conversion.

