### PR TITLE
Unicode printing and AsRef consistency

### DIFF
--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -18,6 +18,18 @@ pub trait FromNative<T> {
     unsafe fn from_native(input: T) -> Self;
 }
 
+impl<'a, T, U: AsNative<T> + ?Sized> AsNative<T> for &'a U {
+    unsafe fn as_native(&self) -> &T {
+        (**self).as_native()
+    }
+}
+
+impl <T, U: AsNative<T> + ?Sized> AsNative<T> for Box<U> {
+    unsafe fn as_native(&self) -> &T {
+        (**self).as_native()
+    }
+}
+
 pub fn keycode_from_u32(input: u32) -> Option<KeyCode> {
     match input {
         0 => Some(KeyCode::NoKey),

--- a/src/console.rs
+++ b/src/console.rs
@@ -447,6 +447,7 @@ impl<'a> RootInitializer<'a> {
     }
 
     pub fn title<T>(&mut self, title: T) -> &mut RootInitializer<'a> where T: AsRef<str> + 'a {
+        assert!(title.as_ref().is_ascii());
         self.title = Box::new(title);
         self
     }
@@ -862,7 +863,10 @@ pub trait Console : AsNative<ffi::TCOD_console_t> {
         assert!(x >= 0 && y >= 0 && width >= 0 && height >= 0);
         assert!(x + width < self.width() && y + height < self.height());
         let c_title: *const c_char = match title {
-            Some(s) => CString::new(s.as_ref()).unwrap().as_ptr(),
+            Some(s) => {
+                assert!(s.as_ref().is_ascii());
+                CString::new(s.as_ref()).unwrap().as_ptr()
+            },
             None => std::ptr::null(),
         };
         unsafe {

--- a/src/console.rs
+++ b/src/console.rs
@@ -750,7 +750,7 @@ pub trait Console : AsNative<ffi::TCOD_console_t> {
         } else {
             let c_text = text.chars().collect::<Vec<_>>();
             unsafe {
-                ffi::TCOD_console_print_utf(*self.as_native(), x, y, c_text.as_ptr() as *const i32);
+                ffi::TCOD_console_print_rect_utf(*self.as_native(), x, y, width, height, c_text.as_ptr() as *const i32);
             }
         }
     }

--- a/src/console_macros.rs
+++ b/src/console_macros.rs
@@ -3,62 +3,62 @@ macro_rules! tcod_print {
     // ABW
     ($con: expr, At($x: expr, $y: expr), Align($alignment: expr),
      Bg($bg: expr), Wrap($width: expr, $height: expr), $($arg: tt)*) => (
-        $con.print_rect_ex($x, $y, $width, $height, $bg, $alignment, format!($($arg)*).as_ref());
+        $con.print_rect_ex($x, $y, $width, $height, $bg, $alignment, format!($($arg)*));
     );
 
     // AWB
     ($con: expr, At($x: expr, $y: expr), Align($alignment: expr),
      Wrap($width: expr, $height: expr), Bg($bg: expr), $($arg: tt)*) => (
-        $con.print_rect_ex($x, $y, $width, $height, $bg, $alignment, format!($($arg)*).as_ref());
+        $con.print_rect_ex($x, $y, $width, $height, $bg, $alignment, format!($($arg)*));
     );
 
     // BAW
     ($con: expr, At($x: expr, $y: expr), Bg($bg: expr),
      Align($alignment: expr), Wrap($width: expr, $height: expr), $($arg: tt)*) => (
-        $con.print_rect_ex($x, $y, $width, $height, $bg, $alignment, format!($($arg)*).as_ref());
+        $con.print_rect_ex($x, $y, $width, $height, $bg, $alignment, format!($($arg)*));
     );
 
     // BWA
     ($con: expr, At($x: expr, $y: expr), Bg($bg: expr),
      Wrap($width: expr, $height: expr), Align($alignment: expr), $($arg: tt)*) => (
-        $con.print_rect_ex($x, $y, $width, $height, $bg, $alignment, format!($($arg)*).as_ref());
+        $con.print_rect_ex($x, $y, $width, $height, $bg, $alignment, format!($($arg)*));
     );
 
     // WAB
     ($con: expr, At($x: expr, $y: expr), Wrap($width: expr, $height: expr),
      Align($alignment: expr), Bg($bg: expr), $($arg: tt)*) => (
-        $con.print_rect_ex($x, $y, $width, $height, $bg, $alignment, format!($($arg)*).as_ref());
+        $con.print_rect_ex($x, $y, $width, $height, $bg, $alignment, format!($($arg)*));
     );
 
     // WBA
     ($con: expr, At($x: expr, $y: expr), Wrap($width: expr, $height: expr),
      Bg($bg: expr), Align($alignment: expr), $($arg: tt)*) => (
-        $con.print_rect_ex($x, $y, $width, $height, $bg, $alignment, format!($($arg)*).as_ref());
+        $con.print_rect_ex($x, $y, $width, $height, $bg, $alignment, format!($($arg)*));
     );
 
     // AB
     ($con: expr, At($x: expr, $y: expr), Align($bg: expr), Bg($alignment: expr), $($arg: tt)*) => (
-        $con.print_ex($x, $y, $bg, $alignment, format!($($arg)*).as_ref());
+        $con.print_ex($x, $y, $bg, $alignment, format!($($arg)*));
     );
 
     // AW
     ($con: expr, At($x: expr, $y: expr), Align($alignment: expr), Wrap($width: expr, $height: expr), $($arg: tt)*) => (
         {
             let bg = $con.get_background_flag();
-            $con.print_rect_ex($x, $y, $width, $height, bg, $alignment, format!($($arg)*).as_ref());
+            $con.print_rect_ex($x, $y, $width, $height, bg, $alignment, format!($($arg)*));
         }
     );
 
     // BA
     ($con: expr, At($x: expr, $y: expr), Bg($bg: expr), Align($alignment: expr), $($arg: tt)*) => (
-        $con.print_ex($x, $y, $bg, $alignment, format!($($arg)*).as_ref());
+        $con.print_ex($x, $y, $bg, $alignment, format!($($arg)*));
     );
 
     // BW
     ($con: expr, At($x: expr, $y: expr), Bg($bg: expr), Wrap($width: expr, $height: expr), $($arg: tt)*) => (
         {
             let alignment = $con.get_alignment();
-            $con.print_rect_ex($x, $y, $width, $height, $bg, alignment, format!($($arg)*).as_ref());
+            $con.print_rect_ex($x, $y, $width, $height, $bg, alignment, format!($($arg)*));
         }
     );
 
@@ -66,7 +66,7 @@ macro_rules! tcod_print {
     ($con: expr, At($x: expr, $y: expr), Wrap($width: expr, $height: expr), Align($alignment: expr), $($arg: tt)*) => (
         {
             let bg = $con.get_background_flag();
-            $con.print_rect_ex($x, $y, $width, $height, bg, $alignment, format!($($arg)*).as_ref());
+            $con.print_rect_ex($x, $y, $width, $height, bg, $alignment, format!($($arg)*));
         }
     );
 
@@ -74,7 +74,7 @@ macro_rules! tcod_print {
     ($con: expr, At($x: expr, $y: expr), Wrap($width: expr, $height: expr), Bg($bg: expr), $($arg: tt)*) => (
         {
             let alignment = $con.get_alignment();
-            $con.print_rect_ex($x, $y, $width, $height, $bg, alignment, format!($($arg)*).as_ref());
+            $con.print_rect_ex($x, $y, $width, $height, $bg, alignment, format!($($arg)*));
         }
     );
 
@@ -82,7 +82,7 @@ macro_rules! tcod_print {
     ($con: expr, At($x: expr, $y: expr), Align($alignment: expr), $($arg: tt)*) => (
         {
             let bg = $con.get_background_flag();
-            $con.print_ex($x, $y, bg, $alignment, format!($($arg)*).as_ref());
+            $con.print_ex($x, $y, bg, $alignment, format!($($arg)*));
         }
     );
 
@@ -90,17 +90,17 @@ macro_rules! tcod_print {
     ($con: expr, At($x: expr, $y: expr), Bg($bg: expr), $($arg: tt)*) => (
         {
             let alignment = $con.get_alignment();
-            $con.print_ex($x, $y, $bg, alignment, format!($($arg)*).as_ref());
+            $con.print_ex($x, $y, $bg, alignment, format!($($arg)*));
         }
     );
 
     // W
     ($con: expr, At($x: expr, $y: expr), Wrap($width: expr, $height: expr), $($arg: tt)*) => (
-        $con.print_rect($x, $y, $width, $height, format!($($arg)*).as_ref());
+        $con.print_rect($x, $y, $width, $height, format!($($arg)*));
     );
 
     // None
     ($con: expr, At($x: expr, $y: expr), $($arg: tt)*) => (
-        $con.print($x, $y, format!($($arg)*).as_ref());
+        $con.print($x, $y, format!($($arg)*));
     );
 }

--- a/src/system.rs
+++ b/src/system.rs
@@ -41,7 +41,7 @@ pub fn get_elapsed_time() -> Duration {
     return Duration::milliseconds(ms as i64)
 }
 
-pub fn save_screenshot<P: AsRef<Path>>(path: P) {
+pub fn save_screenshot<P>(path: P) where P: AsRef<Path> {
     let filename = path.as_ref().to_str().unwrap();
     let c_path = std::ffi::CString::new(filename).unwrap();
     unsafe {
@@ -89,8 +89,8 @@ pub fn get_char_size() -> (i32, i32) {
     (width, height)
 }
 
-pub fn set_clipboard(value: &str) {
-    let c_str = std::ffi::CString::new(value.as_bytes()).unwrap();
+pub fn set_clipboard<T>(value: T) where T: AsRef<str> {
+    let c_str = std::ffi::CString::new(value.as_ref().as_bytes()).unwrap();
     unsafe {
         ffi::TCOD_sys_clipboard_set(c_str.as_ptr());
     }


### PR DESCRIPTION
Implementation as per #161 and #162

As far as I could tell everything works fine. The example mentioned in #161 (printing `b"90\xf8"`) also works correctly, provided we use the Unicode equivalent of the special character: `"90\u{f8}"`. It also seems like there is no need to implement separate printing for single characters: `TCOD_console_put_char_xx` and `TCOD_console_set_char` already take `i32` as their arguments, which `char` can be easily casted to (as it is done now).