### PR TITLE
Support for proper printing of ASCII literals

### DIFF
--- a/examples/text.rs
+++ b/examples/text.rs
@@ -6,9 +6,9 @@ fn main() {
     let mut root = RootConsole::initializer().size(80, 50).title("Displaying text").init();
 
     root.print_ex(1, 1, BackgroundFlag::None, TextAlignment::Left,
-                  "Text aligned to left.");
+                  b"Ascii text aligned to left.\xf8");
     root.print_ex(78, 1, BackgroundFlag::None, TextAlignment::Right,
-                  "Text aligned to right.");
+                  "Unicode text aligned to right.\u{f8}");
     root.print_ex(40, 15, BackgroundFlag::None, TextAlignment::Center,
                   "And this bit of text is centered.");
     root.print_ex(40, 19, BackgroundFlag::None, TextAlignment::Center,

--- a/src/console.rs
+++ b/src/console.rs
@@ -526,6 +526,12 @@ impl TcodString for String {
     }
 }
 
+impl<'a> TcodString for &'a String {
+    fn as_ascii(&self) -> Option<&[u8]> {
+        AsRef::<str>::as_ref(self).as_ascii()
+    }
+}
+
 trait AsciiLiteral {}
 impl AsciiLiteral for [u8] {}
 


### PR DESCRIPTION
I wrote a detailed summary of my opinions in #161, but here's a possible implementation for the ASCII literal printing. This actually works quite well, and as soon as Rust has negative trait bounds we can implement `TcodString` for `AsRef<str>` as well. The obvious limitation is the hard coded limit on the fixed size arrays, but note that even the standard library only implements traits for fixed-sized arrays up to  the [size 32](https://doc.rust-lang.org/nightly/core/primitive.array.html).

Other than that I think this works as most users would expect: ASCII literals in Rust guarantee that for each character a single byte is passed (with a value of 0-255) which is what `libtcod` expects. In the case of regular strings the UTF conversion occurs if the given string had a character that was outside of the original (0-127) ASCII range. 

Closes #161