### PR TITLE
Add `Console::get_height_rect`

### DIFF
--- a/examples/text.rs
+++ b/examples/text.rs
@@ -13,6 +13,10 @@ fn main() {
                   "And this bit of text is centered.");
     root.print_ex(40, 19, BackgroundFlag::None, TextAlignment::Center,
                   "Press any key to quit.");
+
+    let wrapped_text = "This text is wrapped to form X lines: https://xkcd.com/688/";
+    let lines = root.get_height_rect(10, 25, 22, 10, wrapped_text);
+    root.print_rect(10, 25, 22, 10, wrapped_text.replace("X", &lines.to_string()));
     root.flush();
     root.wait_for_keypress(true);
 }

--- a/src/console.rs
+++ b/src/console.rs
@@ -898,6 +898,27 @@ pub trait Console : AsNative<ffi::TCOD_console_t> {
         }
     }
 
+    /// Compute the height of a wrapped text printed using `print_rect` or `print_rect_ex`.
+    ///
+    /// While the print functions accept strings with non-ASCII characters,
+    /// there is no unicode equivalent for this function in libtcod. You must
+    /// pass a text with ASCII characters only.
+    fn get_height_rect<T>(&self,
+                          x: i32, y: i32,
+                          width: i32, height: i32,
+                          text: T) -> i32 where Self: Sized, T: AsRef<[u8]> + TcodString {
+        assert!(x >= 0 && y >= 0 && width >= 0 && height >= 0);
+        assert!(x + width < self.width() && y + height < self.height());
+        let ascii_text = text.as_ascii().expect(
+            "libtcod doesn't have a unicode version of `TCOD_console_get_height_rect`.");
+        let c_text = CString::new(ascii_text).unwrap();
+        unsafe {
+            ffi::TCOD_console_get_height_rect(*self.as_native(), x, y, width, height,
+                                              c_text.as_ptr())
+        }
+    }
+
+
     /// Fill a rectangle with the default background colour.
     ///
     /// If `clear` is true, set each cell's character to space (ASCII 32).

--- a/src/console.rs
+++ b/src/console.rs
@@ -899,22 +899,27 @@ pub trait Console : AsNative<ffi::TCOD_console_t> {
     }
 
     /// Compute the height of a wrapped text printed using `print_rect` or `print_rect_ex`.
-    ///
-    /// While the print functions accept strings with non-ASCII characters,
-    /// there is no unicode equivalent for this function in libtcod. You must
-    /// pass a text with ASCII characters only.
     fn get_height_rect<T>(&self,
                           x: i32, y: i32,
                           width: i32, height: i32,
                           text: T) -> i32 where Self: Sized, T: AsRef<[u8]> + TcodString {
         assert!(x >= 0 && y >= 0 && width >= 0 && height >= 0);
         assert!(x + width < self.width() && y + height < self.height());
-        let ascii_text = text.as_ascii().expect(
-            "libtcod doesn't have a unicode version of `TCOD_console_get_height_rect`.");
-        let c_text = CString::new(ascii_text).unwrap();
-        unsafe {
-            ffi::TCOD_console_get_height_rect(*self.as_native(), x, y, width, height,
-                                              c_text.as_ptr())
+        match text.as_ascii() {
+            Some(text) => {
+                let c_text = CString::new(text).unwrap();
+                unsafe {
+                    ffi::TCOD_console_get_height_rect(*self.as_native(), x, y, width, height,
+                                                      c_text.as_ptr())
+                }
+            }
+            None => {
+                let c_text = str::from_utf8(text.as_ref()).unwrap().chars().collect::<Vec<_>>();
+                unsafe {
+                    ffi::TCOD_console_get_height_rect_utf(*self.as_native(), x, y, width, height,
+                                                          c_text.as_ptr() as *const i32)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This can only be used with ASCII strings, unfortunately.