### PR TITLE
Name Generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ rusti.sh
 watch.sh
 /examples/**
 !/examples/*.rs
+!/examples/*.txt
 !/examples/assets/
 *Cargo.lock
 /tcod_sys/target/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,12 +31,13 @@ doctest = false
 
 [dependencies]
 bitflags = "0.1"
-libc = "0.1.5"
-time = "0.1.25"
+libc = "0.1"
+time = "0.1"
+lazy_static = "0.1"
 
 [dependencies.tcod-sys]
 path = "tcod_sys"
-version = "2.0.12"
+version = "2.0"
 
 [dev-dependencies]
-rand = "0.3.8"
+rand = "0.3"

--- a/examples/namegen.rs
+++ b/examples/namegen.rs
@@ -1,10 +1,16 @@
  extern crate tcod;
 
 use tcod::namegen::Namegen;
-use tcod::random::Rng;
+use tcod::random::{Rng, Algo};
+
+fn setup_namegen() -> Namegen {
+    let rng = Rng::new(Algo::MT);
+    let mut namegen = Namegen::new().unwrap();
+    namegen.parse_with_rng("examples/names.txt", &rng);
+    namegen
+}
 
 fn main() {
-    Namegen::parse("examples/names.txt", Rng::get_instance());
-    println!("{}", Namegen::generate("king").unwrap());
-    Namegen::reset();
+    let namegen = setup_namegen();
+    println!("{}", namegen.generate("king").unwrap());
 }

--- a/examples/namegen.rs
+++ b/examples/namegen.rs
@@ -1,0 +1,10 @@
+ extern crate tcod;
+
+use tcod::namegen::Namegen;
+use tcod::random::Rng;
+
+fn main() {
+    Namegen::parse("examples/names.txt", Rng::get_instance());
+    println!("{}", Namegen::generate("king").unwrap());
+    Namegen::reset();
+}

--- a/examples/names.txt
+++ b/examples/names.txt
@@ -1,0 +1,12 @@
+name "king" {
+syllablesStart = "Alexander, Augustus, Casimir, Henry, John, Louis, Sigismund,"
+"Stanislao, Stephen, Wenceslaus"
+syllablesMiddle = "I, II, III, IV, V"
+syllablesEnd = "Bathory, Herman, Jogaila, Lambert, of_Bohemia, of_France,"
+"of_Hungary, of_Masovia, of_Poland, of_Valois, of_Varna, Probus,"
+"Spindleshanks, Tanglefoot, the_Bearded, the_Black, the_Bold, the_Brave,"
+"the_Chaste, the_Curly, the_Elbow-high, the_Exile, the_Great,"
+"the_Jagiellonian, the_Just, the_Old, the_Pious, the_Restorer, the_Saxon,"
+"the_Strong, the_Wheelwright, the_White, Vasa, Wrymouth"
+rules = "%50$s, $s_$m, $s_$50m_$e"
+}

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1,8 +1,7 @@
-extern crate std;
 extern crate libc;
 extern crate tcod_sys as ffi;
 
-pub use self::std::ffi::CString;
+pub use std::ffi::CString;
 pub use self::libc::{c_char, c_int, c_float, c_uint, c_void, uint8_t};
 
 use super::input::KeyCode;

--- a/src/console.rs
+++ b/src/console.rs
@@ -53,13 +53,12 @@
 //! ```
 //! This applies to all the examples in the rest of the modules documentation.
 
-
-extern crate std;
+use std::ptr;
+use std::str;
 
 use std::ascii::AsciiExt;
 use std::marker::PhantomData;
 use std::path::Path;
-use std::str;
 
 use bindings::ffi;
 use bindings::{AsNative, FromNative, c_bool, c_char, CString, keycode_from_u32};
@@ -986,7 +985,7 @@ pub trait Console : AsNative<ffi::TCOD_console_t> {
                 assert!(s.as_ref().is_ascii());
                 CString::new(s.as_ref()).unwrap().as_ptr()
             },
-            None => std::ptr::null(),
+            None => ptr::null(),
         };
         unsafe {
             ffi::TCOD_console_print_frame(*self.as_native(), x, y, width, height,

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,4 +1,4 @@
-extern crate std;
+use std::ptr;
 
 use bindings::ffi;
 use bindings::{c_bool, c_char, c_uint, keycode_from_u32};
@@ -190,13 +190,13 @@ pub fn check_for_event(event_mask: EventFlags) -> Option<(EventFlags, Event)> {
             if event_mask.intersects(KEY_PRESS|KEY_RELEASE|KEY|ANY) {
                 &mut c_key_state
             } else {
-                std::ptr::null_mut()
+                ptr::null_mut()
             },
             if event_mask.intersects(
                 MOUSE_MOVE|MOUSE_PRESS|MOUSE_RELEASE|MOUSE|ANY) {
                 &mut c_mouse_state
             } else {
-                std::ptr::null_mut()
+                ptr::null_mut()
             })
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ pub mod colors;
 pub mod console;
 pub mod input;
 pub mod map;
+pub mod namegen;
 pub mod pathfinding;
 pub mod system;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub mod input;
 pub mod map;
 pub mod namegen;
 pub mod pathfinding;
+pub mod random;
 pub mod system;
 
 mod bindings;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@
 //!
 
 #[macro_use] extern crate bitflags;
+#[macro_use] extern crate lazy_static;
 
 pub use bindings::{AsNative, FromNative};
 pub use colors::Color;

--- a/src/namegen.rs
+++ b/src/namegen.rs
@@ -1,15 +1,88 @@
 use std::ptr;
 use std::str;
 use std::ffi::{CStr, CString};
-use std::marker::PhantomData;
 use std::path::Path;
+use std::sync::Mutex;
 
 use bindings::ffi;
 use bindings::{AsNative, c_char};
 use random::Rng;
 
+static mut NAMEGEN_FREE: bool = true;
+lazy_static! {
+    static ref NAMEGEN_MUTEX: Mutex<()> = Mutex::new(());
+}
+
 pub struct Namegen {
-    _blocker: PhantomData<Namegen>
+    rng: Vec<Rng>,
+}
+
+impl Drop for Namegen {
+    fn drop(&mut self) {
+        unsafe {
+            let _lock = NAMEGEN_MUTEX.lock().unwrap();
+            ffi::TCOD_namegen_destroy();
+            NAMEGEN_FREE = true;
+        }
+    }
+}
+
+impl Namegen {
+    pub fn new() -> Option<Namegen> {
+        unsafe {
+            match NAMEGEN_FREE {
+                true => {
+                    let _lock = NAMEGEN_MUTEX.lock().unwrap();
+                    NAMEGEN_FREE = false;
+                    Some(Namegen { rng: Vec::new() })
+                },
+                false => None
+            }
+        }
+    }
+
+    pub fn parse<T>(&mut self, path: T) where T: AsRef<Path> {
+        self.parse_with_rng(path, &Rng::get_instance())
+    }
+
+    pub fn parse_with_rng<T>(&mut self, path: T, rng: &Rng) where T: AsRef<Path> {
+        self.rng.push(rng.save());
+
+        let path_string = CString::new(path.as_ref().to_str().unwrap()).unwrap();
+        unsafe {
+            ffi::TCOD_namegen_parse(path_string.as_ptr(), *self.rng.last().unwrap().as_native());
+        }
+    }
+
+    pub fn generate<T>(&self, name: T) -> Option<String> where T: AsRef<str> {
+        unsafe {
+            let name_string = CString::new(name.as_ref()).unwrap();
+            let borrowed = ffi::TCOD_namegen_generate(name_string.as_ptr() as *mut _, 0);
+            cstr_to_owned(borrowed)
+        }
+    }
+
+    pub fn generate_custom<T, U>(&self, name: T, rule: U) -> Option<String> where T: AsRef<str>, U: AsRef<str> {
+        unsafe {
+            let name_string = CString::new(name.as_ref()).unwrap();
+            let rule_string = CString::new(rule.as_ref()).unwrap();
+
+            let borrowed = ffi::TCOD_namegen_generate_custom(name_string.as_ptr() as *mut _, rule_string.as_ptr() as *mut _, 0);
+            cstr_to_owned(borrowed)
+        }
+    }
+
+    pub fn get_sets(&self) -> Vec<String> {
+        unsafe {
+            let list = ffi::TCOD_namegen_get_sets();
+            let size = ffi::TCOD_list_size(list);
+            let mut ret = Vec::with_capacity(size as usize);
+            for i in 0..size {
+                ret.push(cstr_to_owned(ffi::TCOD_list_get(list, i) as *mut c_char).unwrap());
+            }
+            ret
+        }
+    }
 }
 
 #[inline]
@@ -25,52 +98,4 @@ fn cstr_to_owned(string: *mut c_char) -> Option<String> {
             .ok()
     }
 }
-
-//TODO: Some kind of alternative API? This is not very Rusty, but global state is not very Rusty in
-//general.
-impl Namegen {
-    pub fn parse<T>(path: T, rng: Rng) where T: AsRef<Path> {
-        let path_string = CString::new(path.as_ref().to_str().unwrap()).unwrap();
-        unsafe {
-            ffi::TCOD_namegen_parse(path_string.as_ptr(), *rng.as_native());
-        }
-    }
-
-    pub fn reset() {
-        unsafe {
-            ffi::TCOD_namegen_destroy();
-        }
-    }
-
-    pub fn generate<T>(name: T) -> Option<String> where T: AsRef<str> {
-        unsafe {
-            let name_string = CString::new(name.as_ref()).unwrap();
-            let borrowed = ffi::TCOD_namegen_generate(name_string.as_ptr() as *mut _, 0);
-            cstr_to_owned(borrowed)
-        }
-    }
-
-    pub fn generate_custom<T, U>(name: T, rule: U) -> Option<String> where T: AsRef<str>, U: AsRef<str> {
-        unsafe {
-            let name_string = CString::new(name.as_ref()).unwrap();
-            let rule_string = CString::new(rule.as_ref()).unwrap();
-
-            let borrowed = ffi::TCOD_namegen_generate_custom(name_string.as_ptr() as *mut _, rule_string.as_ptr() as *mut _, 0);
-            cstr_to_owned(borrowed)
-        }
-    }
-
-    pub fn get_sets() -> Vec<String> {
-        unsafe {
-            let list = ffi::TCOD_namegen_get_sets();
-            let size = ffi::TCOD_list_size(list);
-            let mut ret = Vec::with_capacity(size as usize);
-            for i in 0..size {
-                ret.push(cstr_to_owned(ffi::TCOD_list_get(list, i) as *mut c_char).unwrap());
-            }
-            ret
-        }
-    }
-}
-
 

--- a/src/namegen.rs
+++ b/src/namegen.rs
@@ -1,0 +1,76 @@
+use std::ptr;
+use std::str;
+use std::ffi::{CStr, CString};
+use std::marker::PhantomData;
+use std::path::Path;
+
+use bindings::ffi;
+use bindings::{AsNative, c_char};
+use random::Rng;
+
+pub struct Namegen {
+    _blocker: PhantomData<Namegen>
+}
+
+#[inline]
+fn cstr_to_owned(string: *mut c_char) -> Option<String> {
+    if string == ptr::null::<c_char>() as *mut _ {
+        return None;
+    }
+
+    unsafe {
+        let string = CStr::from_ptr(string);
+        str::from_utf8(string.to_bytes())
+            .map(|x| x.to_owned())
+            .ok()
+    }
+}
+
+//TODO: Some kind of alternative API? This is not very Rusty, but global state is not very Rusty in
+//general.
+impl Namegen {
+    pub fn parse<T>(path: T, rng: Rng) where T: AsRef<Path> {
+        let path_string = CString::new(path.as_ref().to_str().unwrap()).unwrap();
+        unsafe {
+            ffi::TCOD_namegen_parse(path_string.as_ptr(), *rng.as_native());
+        }
+    }
+
+    pub fn reset() {
+        unsafe {
+            ffi::TCOD_namegen_destroy();
+        }
+    }
+
+    pub fn generate<T>(name: T) -> Option<String> where T: AsRef<str> {
+        unsafe {
+            let name_string = CString::new(name.as_ref()).unwrap();
+            let borrowed = ffi::TCOD_namegen_generate(name_string.as_ptr() as *mut _, 0);
+            cstr_to_owned(borrowed)
+        }
+    }
+
+    pub fn generate_custom<T, U>(name: T, rule: U) -> Option<String> where T: AsRef<str>, U: AsRef<str> {
+        unsafe {
+            let name_string = CString::new(name.as_ref()).unwrap();
+            let rule_string = CString::new(rule.as_ref()).unwrap();
+
+            let borrowed = ffi::TCOD_namegen_generate_custom(name_string.as_ptr() as *mut _, rule_string.as_ptr() as *mut _, 0);
+            cstr_to_owned(borrowed)
+        }
+    }
+
+    pub fn get_sets() -> Vec<String> {
+        unsafe {
+            let list = ffi::TCOD_namegen_get_sets();
+            let size = ffi::TCOD_list_size(list);
+            let mut ret = Vec::with_capacity(size as usize);
+            for i in 0..size {
+                ret.push(cstr_to_owned(ffi::TCOD_list_get(list, i) as *mut c_char).unwrap());
+            }
+            ret
+        }
+    }
+}
+
+

--- a/src/random.rs
+++ b/src/random.rs
@@ -1,0 +1,117 @@
+use bindings::ffi;
+use bindings::AsNative;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub enum Distribution {
+    Linear = ffi::TCOD_DISTRIBUTION_LINEAR as isize,
+    Gaussian = ffi::TCOD_DISTRIBUTION_GAUSSIAN as isize,
+    GaussianRange = ffi::TCOD_DISTRIBUTION_GAUSSIAN_RANGE as isize,
+    GaussianInverse = ffi::TCOD_DISTRIBUTION_GAUSSIAN_INVERSE as isize,
+    GaussianRangeInverse = ffi::TCOD_DISTRIBUTION_GAUSSIAN_RANGE_INVERSE as isize,
+
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub enum Algo {
+    MT = ffi::TCOD_RNG_MT as isize,
+    CMWC = ffi::TCOD_RNG_CMWC as isize
+}
+
+pub struct Rng {
+    tcod_random: ffi::TCOD_random_t,
+    default: bool
+}
+
+impl Rng {
+    pub fn get_instance() -> Rng {
+        unsafe {
+            Rng { tcod_random: ffi::TCOD_random_get_instance(), default: true }
+        }
+    }
+
+    pub fn new(algo: Algo) -> Rng {
+        unsafe {
+            Rng { tcod_random: ffi::TCOD_random_new(algo as u32), default: false }
+        }
+    }
+
+    pub fn new_with_seed(algo: Algo, seed: u32) -> Rng {
+        unsafe {
+            Rng { tcod_random: ffi::TCOD_random_new_from_seed(algo as u32, seed), default: false }
+        }
+    }
+
+    pub fn save(&self) -> Rng {
+        unsafe {
+            Rng { tcod_random: ffi::TCOD_random_save(self.tcod_random), default: false }
+        }
+    }
+
+    pub fn restore(&mut self, backup: &Rng) {
+        unsafe {
+            ffi::TCOD_random_restore(self.tcod_random, backup.tcod_random);
+        }
+    }
+
+    pub fn set_distribution(&self, distribution: Distribution) {
+        unsafe {
+            ffi::TCOD_random_set_distribution(self.tcod_random, distribution as u32);
+        }
+    }
+
+    pub fn get_int(&self, min: i32, max: i32) -> i32 {
+        unsafe {
+            ffi::TCOD_random_get_int(self.tcod_random, min, max)
+        }
+    }
+
+    pub fn get_int_mean(&self, min: i32, max: i32, mean: i32) -> i32 {
+        unsafe {
+            ffi::TCOD_random_get_int_mean(self.tcod_random,  min, max, mean)
+        }
+    }
+
+    pub fn get_float(&self, min: f32, max: f32) -> f32 {
+        unsafe {
+            ffi::TCOD_random_get_float(self.tcod_random, min, max)
+        }
+    }
+
+    pub fn get_float_mean(&self, min: f32, max: f32, mean: f32) -> f32 {
+        unsafe {
+            ffi::TCOD_random_get_float_mean(self.tcod_random, min, max, mean)
+        }
+    }
+
+    pub fn get_double(&self, min: f64, max: f64) -> f64 {
+        unsafe {
+            ffi::TCOD_random_get_double(self.tcod_random, min, max)
+        }
+    }
+
+    pub fn get_double_mean(&self, min: f64, max: f64, mean: f64) -> f64 {
+        unsafe {
+            ffi::TCOD_random_get_double_mean(self.tcod_random, min, max, mean)
+        }
+    }
+}
+
+impl AsNative<ffi::TCOD_random_t> for Rng {
+    unsafe fn as_native(&self) -> &ffi::TCOD_random_t {
+        &self.tcod_random
+    }
+}
+
+impl Drop for Rng {
+    fn drop(&mut self) {
+        if !self.default {
+            unsafe {
+                ffi::TCOD_random_delete(self.tcod_random);
+            }
+        }
+    }
+}
+
+

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,6 +1,9 @@
-extern crate std;
 extern crate time;
 
+use std::str;
+use std::ptr;
+
+use std::ffi::{CStr, CString};
 use std::path::Path;
 use bindings::ffi;
 
@@ -43,7 +46,7 @@ pub fn get_elapsed_time() -> Duration {
 
 pub fn save_screenshot<P>(path: P) where P: AsRef<Path> {
     let filename = path.as_ref().to_str().unwrap();
-    let c_path = std::ffi::CString::new(filename).unwrap();
+    let c_path = CString::new(filename).unwrap();
     unsafe {
         ffi::TCOD_sys_save_screenshot(c_path.as_ptr());
     }
@@ -51,7 +54,7 @@ pub fn save_screenshot<P>(path: P) where P: AsRef<Path> {
 
 pub fn save_screenshot_auto() {
     unsafe {
-        ffi::TCOD_sys_save_screenshot(std::ptr::null());
+        ffi::TCOD_sys_save_screenshot(ptr::null());
     }
 }
 
@@ -90,7 +93,7 @@ pub fn get_char_size() -> (i32, i32) {
 }
 
 pub fn set_clipboard<T>(value: T) where T: AsRef<str> {
-    let c_str = std::ffi::CString::new(value.as_ref().as_bytes()).unwrap();
+    let c_str = CString::new(value.as_ref().as_bytes()).unwrap();
     unsafe {
         ffi::TCOD_sys_clipboard_set(c_str.as_ptr());
     }
@@ -99,7 +102,7 @@ pub fn set_clipboard<T>(value: T) where T: AsRef<str> {
 pub fn get_clipboard() -> String {
     unsafe {
         let c_ptr = ffi::TCOD_sys_clipboard_get();
-        let c_str = std::ffi::CStr::from_ptr(c_ptr).to_bytes();
-        std::str::from_utf8(c_str).unwrap().to_string()
+        let c_str = CStr::from_ptr(c_ptr).to_bytes();
+        str::from_utf8(c_str).unwrap().to_string()
     }
 }

--- a/tcod_sys/Cargo.toml
+++ b/tcod_sys/Cargo.toml
@@ -14,4 +14,4 @@ name = "tcod_sys"
 path = "lib.rs"
 
 [dependencies]
-libc = "0.1.5"
+libc = "0.1"


### PR DESCRIPTION
Name generation functionality, but I had to wrap to whole pseudorandom-generator module as well (namegen, noise requires this). The name generator has a very obvious limitation: you can only ever have one name generator at any given time. I have no idea how to wrap a global construct more elegantly, but we do need a separate structure to remain memory safe: `libtcod` would happily use random number generators that have already been freed (hence the stored copies in `Namegen`).

If there are any alternative API ideas, I'd be happy to hear them.