### PR TITLE
Zero is a valid value to pass to TCOD_sys_set_fps

### DIFF
--- a/src/system.rs
+++ b/src/system.rs
@@ -10,7 +10,7 @@ use bindings::ffi;
 use self::time::Duration;
 
 pub fn set_fps(fps: i32) {
-    assert!(fps > 0);
+    assert!(fps >= 0);
     unsafe {
         ffi::TCOD_sys_set_fps(fps)
     }


### PR DESCRIPTION
Libtcod documentation states of `TCOD_sys_set_fps`: "Maximum number of frames per second. 0 means unlimited frame rate."