### PR TITLE
Small fix for memory leak patch

### DIFF
--- a/tcod_sys/libtcod/src/path_c.c
+++ b/tcod_sys/libtcod/src/path_c.c
@@ -663,10 +663,7 @@ void TCOD_dijkstra_delete (TCOD_dijkstra_t dijkstra) {
 	TCOD_IFNOT(data != NULL) return;
 	if ( data->distances ) free(data->distances);
 	if ( data->nodes ) free(data->nodes);
-	if ( data->path ) {
-		TCOD_list_clear_and_delete(data->path);
-		TCOD_list_delete(data->path);
-	}
+	if ( data->path ) TCOD_list_delete(data->path);
 	free(data);
 }
 


### PR DESCRIPTION
Sorry about this, the `libtcod` lists don't actually own the data they contain, so deleting the list instead of clearing (the original, buggy behavior) is enough.