### PR TITLE
Key reform

### DIFF
--- a/examples/keyboard.rs
+++ b/examples/keyboard.rs
@@ -1,7 +1,7 @@
 extern crate tcod;
 
 use tcod::{Console, RootConsole, BackgroundFlag};
-use tcod::input::Key::Special;
+use tcod::input::Key;
 use tcod::input::KeyCode::{Up, Down, Left, Right, Escape};
 
 fn main() {
@@ -20,12 +20,12 @@ fn main() {
         // libtcod 1.5.1 has a bug where `wait_for_keypress` emits two events:
         // one for key down and one for key up. So we ignore the "key up" ones.
         if keypress.pressed {
-            match keypress.key {
-                Special(Escape) => break,
-                Special(Up) => y -= 1,
-                Special(Down) => y += 1,
-                Special(Left) => x -= 1,
-                Special(Right) => x += 1,
+            match keypress {
+                Key { code: Escape, .. } => break,
+                Key { code: Up, .. } => y -= 1,
+                Key { code: Down, .. } => y += 1,
+                Key { code: Left, .. } => x -= 1,
+                Key { code: Right, .. } => x += 1,
                 _ => {}
             }
         }

--- a/examples/roguelike-tutorial-1.rs
+++ b/examples/roguelike-tutorial-1.rs
@@ -8,7 +8,7 @@ extern crate tcod;
 
 use tcod::console::{Root, Console, FontLayout, FontType, BackgroundFlag};
 use tcod::colors;
-use tcod::input::Key::Special;
+use tcod::input::Key;
 use tcod::input::KeyCode::{Up, Down, Left, Right, Escape, Enter};
 
 // actual size of the window
@@ -21,20 +21,20 @@ fn handle_keys(root: &mut Root, player_x: &mut i32, player_y: &mut i32) -> bool 
     // if let Some(keypress) = root.check_for_keypress()  // real-time
     let keypress = root.wait_for_keypress(true);
 
-    match keypress.key {
+    match keypress {
         // Alt+Enter: toggle fullscreen
-        Special(Enter) if keypress.left_alt => {
+        Key { code: Enter, alt: true, .. } => {
             let fullscreen = !root.is_fullscreen();
             root.set_fullscreen(fullscreen);
         }
-        Special(Escape) => {
+        Key { code: Escape, .. } => {
             return true  // exit game
         }
         // movement keys
-        Special(Up) => *player_y -= 1,
-        Special(Down) => *player_y += 1,
-        Special(Left) => *player_x -= 1,
-        Special(Right) => *player_x += 1,
+        Key { code: Up, .. } => *player_y -= 1,
+        Key { code: Down, .. } => *player_y += 1,
+        Key { code: Left, .. } => *player_x -= 1,
+        Key { code: Right, .. } => *player_x += 1,
         _ => {}
     }
     return false;

--- a/examples/roguelike-tutorial-2.rs
+++ b/examples/roguelike-tutorial-2.rs
@@ -8,7 +8,7 @@ extern crate tcod;
 
 use tcod::console::{Root, Offscreen, Console, FontLayout, FontType, BackgroundFlag};
 use tcod::colors::{self, Color};
-use tcod::input::Key::Special;
+use tcod::input::Key;
 use tcod::input::KeyCode::{Up, Down, Left, Right, Escape, Enter};
 
 // actual size of the window
@@ -111,20 +111,20 @@ fn render_all(root: &mut Root, con: &mut Offscreen, objects: &[Object], map: &Ma
 fn handle_keys(root: &mut Root, player: &mut Object, map: &Map) -> bool {
     // if let Some(keypress) = root.check_for_keypress()  // real-time
     let keypress = root.wait_for_keypress(true);  // turn-based
-    match keypress.key {
+    match keypress {
         // Alt+Enter: toggle fullscreen
-        Special(Enter) if keypress.left_alt => {
+        Key { code: Enter, alt: true, .. } => {
             let fullscreen = !root.is_fullscreen();
             root.set_fullscreen(fullscreen);
         }
-        Special(Escape) => {
+        Key { code: Escape, .. } => {
             return true  // exit game
         }
         // movement keys
-        Special(Up) => player.move_by(0, -1, map),
-        Special(Down) => player.move_by(0, 1, map),
-        Special(Left) => player.move_by(-1, 0, map),
-        Special(Right) => player.move_by(1, 0, map),
+        Key { code: Up, .. } => player.move_by(0, -1, map),
+        Key { code: Down, .. } => player.move_by(0, 1, map),
+        Key { code: Left, .. } => player.move_by(-1, 0, map),
+        Key { code: Right, .. } => player.move_by(1, 0, map),
         _ => {}
     }
     return false;

--- a/examples/samples.rs
+++ b/examples/samples.rs
@@ -379,34 +379,34 @@ impl Render for FovSample {
         self.display_map(console, dx, dy, di);
 
         if let Some((_, Event::Key(state))) = event {
-            match state.key {
-                Key::Printable('i') | Key::Printable('I')
+            match state {
+                Key { printable: 'i', .. } | Key { printable: 'I', .. }
                     if self.map.is_walkable(self.px, self.py - 1) =>
                     self.handle_event(console, &mut |s| s.py -= 1),
-                Key::Printable('k') | Key::Printable('K')
+                Key { printable: 'k', .. } | Key { printable: 'K', .. }
                     if self.map.is_walkable(self.px, self.py + 1) =>
                     self.handle_event(console, &mut |s| s.py += 1),
-                Key::Printable('j') | Key::Printable('J')
+                Key { printable: 'j', .. } | Key { printable: 'J', .. }
                     if self.map.is_walkable(self.px - 1, self.py) =>
                     self.handle_event(console, &mut |s| s.px -= 1),
-                Key::Printable('l') | Key::Printable('L')
+                Key { printable: 'l', .. } | Key { printable: 'L', .. }
                     if self.map.is_walkable(self.px + 1, self.py) =>
                     self.handle_event(console, &mut |s| s.px += 1),
-                Key::Printable('t') | Key::Printable('T') => {
+                Key { printable: 't', .. } | Key { printable: 'T', .. } => {
                     self.torch = !self.torch;
                     self.display_help(console);
                 },
-                Key::Printable('w') | Key::Printable('W') => {
+                Key { printable: 'w', .. } | Key { printable: 'W', .. } => {
                     self.light_walls = !self.light_walls;
                     self.display_help(console);
                     self.recompute_fov = true;
                 },
-                Key::Printable('+') => {
+                Key { printable: '+', .. } => {
                     self.next_algorithm();
                     self.display_help(console);
                     self.recompute_fov = true;
                 },
-                Key::Printable('-') => {
+                Key { printable: '-', .. } => {
                     self.previous_algorithm();
                     self.display_help(console);
                     self.recompute_fov = true;
@@ -630,16 +630,16 @@ impl<'a> Render for PathSample<'a> {
         }
 
         if let Some((_, Event::Key(state))) = event {
-            match state.key {
-                Key::Printable('i') | Key::Printable('I') if self.dy > 0 =>
+            match state {
+                Key { printable: 'i', .. } | Key { printable: 'I', .. } if self.dy > 0 =>
                     self.handle_event(console, &mut |s| s.dy -= 1),
-                Key::Printable('k') | Key::Printable('K') if self.dy < SAMPLE_SCREEN_HEIGHT-1 =>
+                Key { printable: 'k', .. } | Key { printable: 'K', .. } if self.dy < SAMPLE_SCREEN_HEIGHT-1 =>
                     self.handle_event(console, &mut |s| s.dy += 1),
-                Key::Printable('j') | Key::Printable('J') if self.dx > 0 =>
+                Key { printable: 'j', .. } | Key { printable: 'J', .. } if self.dx > 0 =>
                     self.handle_event(console, &mut |s| s.dx -= 1),
-                Key::Printable('l') | Key::Printable('L') if self.dx < SAMPLE_SCREEN_WIDTH-1 =>
+                Key { printable: 'l', .. } | Key { printable: 'L', .. } if self.dx < SAMPLE_SCREEN_WIDTH-1 =>
                     self.handle_event(console, &mut |s| s.dx += 1),
-                Key::Special(KeyCode::Tab) => {
+                Key { code: KeyCode::Tab, .. } => {
                     self.using_astar = ! self.using_astar;
                     if self.using_astar {
                         console.print(1, 4, "Using : A*      ");
@@ -806,10 +806,10 @@ impl Render for MouseSample {
 
                 self.mouse_state = Some(mouse);
             },
-            Some((_, Event::Key(state))) if state.key == Key::Special(KeyCode::Number1) => {
+            Some((_, Event::Key(Key {code: KeyCode::Number1, ..}))) => {
                 show_cursor(false);
             },
-            Some((_, Event::Key(state))) if state.key == Key::Special(KeyCode::Number2) => {
+            Some((_, Event::Key(Key {code: KeyCode::Number2, ..}))) => {
                 show_cursor(true)
             },
             _ => {} // Ignore other events
@@ -900,13 +900,13 @@ impl Render for NameSample {
 
         match event {
             Some((_, Event::Key(state))) => {
-                match state.key {
-                    Key::Printable('+') => {
+                match state {
+                    Key { printable: '+', .. } => {
                         self.cur_set += 1;
                         if self.cur_set == self.sets.len() { self.cur_set = 0 }
                         self.names.push("======".to_string());
                     },
-                    Key::Printable('-') => {
+                    Key { printable: '-', .. } => {
                         if self.cur_set == 0 {
                             self.cur_set = self.sets.len() - 1
                         } else {
@@ -1034,24 +1034,24 @@ fn main() {
         match event {
             None => {continue;}
             Some((_flag, Event::Key(state))) => {
-                match state.key {
-                    Key::Special(KeyCode::Down) => {
+                match state {
+                    Key { code: KeyCode::Down, .. } => {
                         cur_sample = (cur_sample + 1) % samples.len();
                         first = true
                     }
-                    Key::Special(KeyCode::Up) => {
+                    Key { code: KeyCode::Up, .. } => {
                         if cur_sample == 0 { cur_sample = samples.len() - 1; }
                         else { cur_sample -= 1; }
                         first = true
                     }
-                    Key::Special(KeyCode::Enter) if state.left_alt => {
+                    Key { code: KeyCode::Enter, .. } if state.left_alt => {
                         let fullscreen = root.is_fullscreen();
                         root.set_fullscreen(!fullscreen)
                     }
-                    Key::Special(KeyCode::PrintScreen) => {
+                    Key { code: KeyCode::PrintScreen, .. } => {
                         // TODO
                     }
-                    Key::Special(KeyCode::Escape) => { break }
+                    Key { code: KeyCode::Escape, .. } => { break }
                     _ => {continue;}
                 }
             }

--- a/examples/samples.rs
+++ b/examples/samples.rs
@@ -745,7 +745,7 @@ struct MouseSample {
     left_button:   bool,
     middle_button: bool,
     right_button:  bool,
-    mouse_state: Option<MouseState>,
+    mouse_state: Option<Mouse>,
 }
 
 impl MouseSample {
@@ -755,7 +755,7 @@ impl MouseSample {
         }
     }
 
-    fn format(&self, mouse: &MouseState, root: &Root) -> String {
+    fn format(&self, mouse: &Mouse, root: &Root) -> String {
         format!("{}\n \
                  Mouse position : {:4}x{:4} {}\n \
                  Mouse cell     : {:4}x{:4}\n \

--- a/src/console.rs
+++ b/src/console.rs
@@ -65,7 +65,7 @@ use bindings::ffi;
 use bindings::{AsNative, FromNative, c_bool, c_char, CString};
 
 use colors::Color;
-use input::{KeyPressFlags, KeyState};
+use input::{Key, KeyPressFlags};
 
 /// A type representing secondary consoles
 ///
@@ -292,7 +292,7 @@ impl Root {
     /// This function will wait for a keypress event from the user, returning the [KeyState](../input/struct.KeyState.html)
     /// that represents the event. If `flush` is true, all pending keypresses are flushed from the
     /// keyboard buffer. If false, it returns the first element from it.
-    pub fn wait_for_keypress(&mut self, flush: bool) -> KeyState {
+    pub fn wait_for_keypress(&mut self, flush: bool) -> Key {
         let tcod_key = unsafe {
             ffi::TCOD_console_wait_for_keypress(flush as c_bool)
         };
@@ -302,7 +302,7 @@ impl Root {
     /// This function checks if the user pressed a key. It returns the
     /// [KeyState](../input/struct.KeyState.html) representing the
     /// event if they have, or `None` if they have not.
-    pub fn check_for_keypress(&self, status: KeyPressFlags) -> Option<KeyState> {
+    pub fn check_for_keypress(&self, status: KeyPressFlags) -> Option<Key> {
         let tcod_key = unsafe {
             ffi::TCOD_console_check_for_keypress(status.bits() as i32)
         };

--- a/src/console.rs
+++ b/src/console.rs
@@ -62,10 +62,10 @@ use std::mem::transmute;
 use std::path::Path;
 
 use bindings::ffi;
-use bindings::{AsNative, FromNative, c_bool, c_char, CString, keycode_from_u32};
+use bindings::{AsNative, FromNative, c_bool, c_char, CString};
 
 use colors::Color;
-use input::{Key, KeyPressFlags, KeyState};
+use input::{KeyPressFlags, KeyState};
 
 /// A type representing secondary consoles
 ///
@@ -296,20 +296,7 @@ impl Root {
         let tcod_key = unsafe {
             ffi::TCOD_console_wait_for_keypress(flush as c_bool)
         };
-        let key = if tcod_key.vk == ffi::TCODK_CHAR {
-            Key::Printable(tcod_key.c as u8 as char)
-        } else {
-            Key::Special(keycode_from_u32(tcod_key.vk).unwrap())
-        };
-        KeyState{
-            key: key,
-            pressed: tcod_key.pressed != 0,
-            left_alt: tcod_key.lalt != 0,
-            left_ctrl: tcod_key.lctrl != 0,
-            right_alt: tcod_key.ralt != 0,
-            right_ctrl: tcod_key.rctrl != 0,
-            shift: tcod_key.shift != 0,
-        }
+        tcod_key.into()
     }
 
     /// This function checks if the user pressed a key. It returns the
@@ -322,20 +309,7 @@ impl Root {
         if tcod_key.vk == ffi::TCODK_NONE {
             return None;
         }
-        let key = if tcod_key.vk == ffi::TCODK_CHAR {
-            Key::Printable(tcod_key.c as u8 as char)
-        } else {
-            Key::Special(keycode_from_u32(tcod_key.vk).unwrap())
-        };
-        Some(KeyState{
-            key: key,
-            pressed: tcod_key.pressed != 0,
-            left_alt: tcod_key.lalt != 0,
-            left_ctrl: tcod_key.lctrl != 0,
-            right_alt: tcod_key.ralt != 0,
-            right_ctrl: tcod_key.rctrl != 0,
-            shift: tcod_key.shift != 0,
-        })
+        Some(tcod_key.into())
     }
 
     /// Returns with true if the `Root` console has been closed.

--- a/src/input.rs
+++ b/src/input.rs
@@ -3,6 +3,10 @@ use std::mem;
 use bindings::ffi;
 use bindings::{c_bool, c_uint, keycode_from_u32};
 
+
+/// Deprecated. Use `tcod::input::mouse` instead.
+pub type MouseState = Mouse;
+
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum KeyCode {
@@ -114,7 +118,7 @@ impl Into<Key> for ffi::TCOD_key_t {
 }
 
 #[derive(Copy, Clone, PartialEq, Debug, Default)]
-pub struct MouseState {
+pub struct Mouse {
     pub x: isize,
     pub y: isize,
     pub dx: isize,
@@ -199,7 +203,7 @@ pub fn check_for_event(event_mask: EventFlags) -> Option<(EventFlags, Event)> {
     let ret_event = if ret_flag.intersects(KEY_PRESS|KEY_RELEASE|KEY) {
         Some(Event::Key(c_key_state.into()))
     } else if ret_flag.intersects(MOUSE_MOVE|MOUSE_PRESS|MOUSE_RELEASE|MOUSE) {
-        Some(Event::Mouse(MouseState {
+        Some(Event::Mouse(Mouse {
             x: c_mouse_state.x as isize,
             y: c_mouse_state.y as isize,
             dx: c_mouse_state.dx as isize,
@@ -231,7 +235,7 @@ pub fn events() -> EventIterator {
 #[derive(Copy, Clone, Debug)]
 pub enum Event {
     Key(Key),
-    Mouse(MouseState)
+    Mouse(Mouse)
 }
 
 pub struct EventIterator;

--- a/src/input.rs
+++ b/src/input.rs
@@ -82,45 +82,33 @@ impl Default for KeyCode {
     }
 }
 
-
-#[derive(Copy, Clone, PartialEq, Debug)]
-pub enum Key {
-    Printable(char),
-    Special(KeyCode),
-}
-
-impl Default for Key {
-    fn default() -> Self {
-        Key::Special(Default::default())
-    }
-}
-
-#[derive(Copy, Clone, PartialEq, Debug)]
-pub struct KeyState {
-    pub key: Key,
+#[derive(Copy, Clone, PartialEq, Debug, Default)]
+pub struct Key {
+    pub code: KeyCode,
+    pub printable: char,
     pub pressed: bool,
     pub left_alt: bool,
     pub left_ctrl: bool,
     pub right_alt: bool,
     pub right_ctrl: bool,
     pub shift: bool,
+    pub alt: bool,
+    pub ctrl: bool,
 }
 
-impl Into<KeyState> for ffi::TCOD_key_t {
-    fn into(self) -> KeyState {
-        let key = if self.vk == ffi::TCODK_CHAR {
-            Key::Printable(self.c as u8 as char)
-        } else {
-            Key::Special(keycode_from_u32(self.vk).unwrap())
-        };
-        KeyState{
-            key: key,
+impl Into<Key> for ffi::TCOD_key_t {
+    fn into(self) -> Key {
+        Key {
+            code: keycode_from_u32(self.vk).unwrap(),
+            printable: self.c as u8 as char,
             pressed: self.pressed != 0,
             left_alt: self.lalt != 0,
             left_ctrl: self.lctrl != 0,
             right_alt: self.ralt != 0,
             right_ctrl: self.rctrl != 0,
             shift: self.shift != 0,
+            alt: self.lalt != 0 || self.ralt != 0,
+            ctrl: self.lctrl != 0 || self.rctrl != 0,
         }
     }
 }
@@ -242,7 +230,7 @@ pub fn events() -> EventIterator {
 
 #[derive(Copy, Clone, Debug)]
 pub enum Event {
-    Key(KeyState),
+    Key(Key),
     Mouse(MouseState)
 }
 


### PR DESCRIPTION
This fixes #184 because of which we couldn't access certain keys. The `KeyState` struct is renamed to `Key` and has fields `code` and `printable` that correspond to libtcod's `vk` and `c`.

This also adds two convenience fields: `alt` and `ctrl` that are true if the left or right variant is pressed.

This is a breaking change. To update your code, convert it to match on the `Key` struct. I.e. replace this:

```rust
match keypress.key {
    Special(Enter) if keypress.left_alt => { // fullscreen }
    Special(Escape) => { // exit game }
    Key::Printable('>') => { // descend }
}
```

with this:

```rust
match keypress {
    Key { code: Enter, alt: true, .. } => { // fullscreen }
    Key { code: Escape, .. } => { // exit game }
    Key { printable: '>', .. } => { // descend }
}
```