### PR TITLE
Fix segfault on an unparsed namegen

### DIFF
--- a/src/namegen.rs
+++ b/src/namegen.rs
@@ -23,7 +23,9 @@ impl Drop for Namegen {
             let _lock = NAMEGEN_MUTEX.lock()
                 .ok()
                 .expect("Namegen mutex could not be locked");
-            ffi::TCOD_namegen_destroy();
+            if self.rng.len() > 0 {
+                ffi::TCOD_namegen_destroy();
+            }
             NAMEGEN_FREE = true;
         }
     }
@@ -103,4 +105,3 @@ fn cstr_to_owned(string: *mut c_char) -> Option<String> {
             .ok()
     }
 }
-


### PR DESCRIPTION
libtcod doesn't have a "namegen new" function. We use `Namegen::new()`
to ensure memory safety. But we cannot call `TCOD_namegen_destroy`
unless we've actually called parse first. We get a segfault otherwise:

```rust
extern crate tcod;
use tcod::namegen::Namegen;

fn main() {
    let namegen = Namegen::new();
}
```

Fixes #189.