### PR TITLE
Safe iterable/wrapping enums

### DIFF
--- a/examples/samples.rs
+++ b/examples/samples.rs
@@ -320,20 +320,6 @@ impl FovSample {
         console.put_char(self.px, self.py, '@', BackgroundFlag::None);
         self.recompute_fov = true;
     }
-
-    fn next_algorithm(&mut self) {
-        match self.algorithm {
-            FovAlgorithm::Restrictive => return,
-            _ => self.algorithm = unsafe { std::mem::transmute(self.algorithm as i32 + 1) }
-        };
-    }
-
-    fn previous_algorithm(&mut self) {
-        match self.algorithm {
-            FovAlgorithm::Basic => return,
-            _ => self.algorithm = unsafe { std::mem::transmute(self.algorithm as i32 - 1) }
-        };
-    }
 }
 
 impl Render for FovSample {
@@ -392,12 +378,12 @@ impl Render for FovSample {
                     self.recompute_fov = true;
                 },
                 '+' => {
-                    self.next_algorithm();
+                    self.algorithm = self.algorithm.bounded_next();
                     self.display_help(console);
                     self.recompute_fov = true;
                 },
                 '-' => {
-                    self.previous_algorithm();
+                    self.algorithm = self.algorithm.bounded_prev();
                     self.display_help(console);
                     self.recompute_fov = true;
                 },

--- a/src/console.rs
+++ b/src/console.rs
@@ -52,13 +52,12 @@
 //! let mut offscreen = OffscreenConsole::new(width, height);
 //! ```
 //! This applies to all the examples in the rest of the modules documentation.
-
+use std::mem;
 use std::ptr;
 use std::str;
 
 use std::ascii::AsciiExt;
 use std::marker::PhantomData;
-use std::mem::transmute;
 use std::path::Path;
 
 use bindings::ffi;
@@ -608,7 +607,7 @@ pub trait Console : AsNative<ffi::TCOD_console_t> {
         let alignment = unsafe {
             ffi::TCOD_console_get_alignment(*self.as_native())
         };
-        unsafe { transmute(alignment) }
+        unsafe { mem::transmute(alignment) }
     }
 
     /// Sets the default text alignment for the console. For all the possible
@@ -679,7 +678,7 @@ pub trait Console : AsNative<ffi::TCOD_console_t> {
         let flag = unsafe {
             ffi::TCOD_console_get_background_flag(*self.as_native())
         };
-        unsafe { transmute(flag) }
+        unsafe { mem::transmute(flag) }
     }
 
     /// Sets the console's current background flag. For a detailed explanation
@@ -1036,7 +1035,7 @@ impl Console for Offscreen {}
 
 /// Represents the text alignment in console instances.
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum TextAlignment {
     Left = ffi::TCOD_LEFT as isize,
     Right = ffi::TCOD_RIGHT as isize,
@@ -1048,7 +1047,7 @@ pub enum TextAlignment {
 /// See [libtcod's documentation](http://doryen.eptalys.net/data/libtcod/doc/1.5.2/html2/console_bkgnd_flag_t.html)
 /// for a detailed description of the different values.
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum BackgroundFlag {
     None = ffi::TCOD_BKGND_NONE as isize,
     Set = ffi::TCOD_BKGND_SET as isize,
@@ -1066,18 +1065,24 @@ pub enum BackgroundFlag {
     Default = ffi::TCOD_BKGND_DEFAULT as isize
 }
 
+iterable_enum!(BackgroundFlag => [None] Set, Multiply, Lighten, Darken, Screen, ColorDodge,
+                                        ColorBurn, Add, AddA, Burn, Overlay, Alph
+                                 [Default]);
+
 /// All the possible renderers used by the `Root` console
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Renderer {
     GLSL = ffi::TCOD_RENDERER_GLSL as isize,
     OpenGL = ffi::TCOD_RENDERER_OPENGL as isize,
     SDL = ffi::TCOD_RENDERER_SDL as isize,
 }
 
+iterable_enum!(Renderer => [GLSL] OpenGL [SDL]);
+
 /// All the possible font layouts that can be used for custom bitmap fonts
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum FontLayout {
     AsciiInCol = ffi::TCOD_FONT_LAYOUT_ASCII_INCOL as isize,
     AsciiInRow = ffi::TCOD_FONT_LAYOUT_ASCII_INROW as isize,
@@ -1085,7 +1090,7 @@ pub enum FontLayout {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum FontType {
     Default = 0,
     Greyscale = ffi::TCOD_FONT_TYPE_GREYSCALE as isize,
@@ -1121,4 +1126,10 @@ mod test {
         let s: &str = &string;
         Root::initializer().font(s, AsciiInCol);
     }
+
+    test_iterable_enum!(iterable_background_flag,
+                        BackgroundFlag => None, Set, Multiply, Lighten, Darken,
+                                          Screen,ColorDodge, ColorBurn, Add, AddA, Burn,
+                                          Overlay, Alph, Default);
+    test_iterable_enum!(iterable_renderer, Renderer => GLSL, OpenGL, SDL);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,13 @@ pub use colors::Color;
 pub use console::{Console, RootInitializer, BackgroundFlag, Renderer, FontLayout, FontType, TextAlignment};
 pub use map::Map;
 
+#[macro_use]
+mod macros;
+mod bindings;
+
+#[macro_use]
+pub mod console_macros;
+
 pub mod chars;
 pub mod colors;
 pub mod console;
@@ -57,8 +64,6 @@ pub mod pathfinding;
 pub mod random;
 pub mod system;
 
-mod bindings;
-mod console_macros;
 
 pub type RootConsole = console::Root;
 pub type OffscreenConsole = console::Offscreen;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,80 @@
+macro_rules! iterable_enum {
+    ($Enum: ident => [$First: ident] $($Variant: ident),* [$Last: ident]) => {
+        impl $Enum {
+            pub fn variants() -> ::std::iter::Cloned<::std::slice::Iter<'static, $Enum>> {
+                static VARIANTS: &'static [$Enum] = &[$Enum::$First, $($Enum::$Variant,)+ $Enum::$Last];
+                VARIANTS.iter().cloned()
+            }
+
+            /// Returns the next variant in an enum. The last variant is infinitely repeated.
+            pub fn bounded_next(self) -> $Enum {
+                match self {
+                    $Enum::$Last => $Enum::$Last,
+                    _ => unsafe { ::std::mem::transmute(self as i32 + 1) },
+                }
+            }
+
+            /// Returns the previous variant in an enum. The first variant is infinitely repeated.
+            pub fn bounded_prev(self) -> $Enum {
+                match self {
+                    $Enum::$First => $Enum::$First,
+                    _ => unsafe { ::std::mem::transmute(self as i32 - 1) },
+                }
+            }
+
+            /// Returns the next variant in an enum. If the last element is reached it wraps around
+            /// to the first element.
+            pub fn cycled_next(self) -> $Enum {
+                match self {
+                    $Enum::$Last => $Enum::$First,
+                    _ => unsafe { ::std::mem::transmute(self as i32 + 1) },
+                }
+            }
+
+            /// Returns the previous variant in an enum. If the first element is reached it wraps around
+            /// to the last element.
+            pub fn cycled_prev(self) -> $Enum {
+                match self {
+                    $Enum::$First => $Enum::$Last,
+                    _ => unsafe { ::std::mem::transmute(self as i32 - 1) },
+                }
+            }
+        }
+    };
+}
+
+macro_rules! test_iterable_enum {
+    ($Test: ident, $Enum: ident => $($Variant: ident),+) => {
+        #[test]
+        fn $Test() {
+            use super::*;
+
+            let variants = [$($Enum::$Variant),+];
+
+            let last = variants.len() - 1;
+            assert_eq!(variants[0].bounded_next(), variants[1]);
+            assert_eq!(variants[0].bounded_prev(), variants[0]);
+            assert_eq!(variants[0].cycled_next(), variants[1]);
+            assert_eq!(variants[0].cycled_prev(), variants[last]);
+
+            for i in 1..last {
+                assert_eq!(variants[i].bounded_next(), variants[i + 1]);
+                assert_eq!(variants[i].bounded_prev(), variants[i - 1]);
+                assert_eq!(variants[i].cycled_next(), variants[i + 1]);
+                assert_eq!(variants[i].cycled_prev(), variants[i - 1]);
+            }
+
+            assert_eq!(variants[last].bounded_next(), variants[last]);
+            assert_eq!(variants[last].bounded_prev(), variants[last - 1]);
+            assert_eq!(variants[last].cycled_next(), variants[0]);
+            assert_eq!(variants[last].cycled_prev(), variants[last - 1]);
+
+            let mut i = 0;
+            for variant in $Enum::variants() {
+                assert_eq!(variant, variants[i]);
+                i += 1;
+            }
+            assert_eq!(i, variants.len());
+        }
+    }
+}

--- a/src/map.rs
+++ b/src/map.rs
@@ -69,7 +69,7 @@ impl Drop for Map {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum FovAlgorithm {
     Basic       = ffi::FOV_BASIC as isize,
     Diamond     = ffi::FOV_DIAMOND as isize,
@@ -84,4 +84,18 @@ pub enum FovAlgorithm {
     Permissive7 = ffi::FOV_PERMISSIVE_7 as isize,
     Permissive8 = ffi::FOV_PERMISSIVE_8 as isize,
     Restrictive = ffi::FOV_RESTRICTIVE as isize,
+}
+
+iterable_enum!(FovAlgorithm => [Basic]
+                               Diamond, Shadow, Permissive0, Permissive1,
+                               Permissive2, Permissive3, Permissive4, Permissive5,
+                               Permissive6, Permissive7, Permissive8
+                               [Restrictive]);
+
+#[cfg(test)]
+mod tests {
+    test_iterable_enum!(iterable_fov_algorithm,
+                        FovAlgorithm => Basic, Diamond, Shadow, Permissive0, Permissive1,
+                                        Permissive2, Permissive3, Permissive4, Permissive5,
+                                        Permissive6, Permissive7, Permissive8, Restrictive);
 }


### PR DESCRIPTION
An example for safe iterable/wrapping enum implementation: I realize that providing this functionality as part of the library is questionable, but there is a problem with providing this implementation in the examples (or leaving it to the users): the `mem::transmute(enum as i32 + 1)` trick is not guaranteed to last forever, upstream could decide (for some reason) to assign actual values to these enums. This version will at least catch the error if you run `cargo test`.

The other question is: is this really necessary? It sure as hell is nice with the `samples` code (especially once #191 is merged), but I don't really see this as something I would use every day. 