### PR TITLE
Updated README to list line toolkit as implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ yet complete, however.
 * _Pseudorandom number generator_ (prefer the `rand` crate, except for places where the API requires the built-in generators)
 * _Name generator_
 * _Image toolkit_
+* _Line toolkit_
 
 ### Probably Won't Ever Be Implemented Because Rust Provides This Already
 * Filesystem utilities


### PR DESCRIPTION
I forgot to add line toolkit to project's README.