### PR TITLE
Replace external `Time` crate with `std::time`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ path = "src/lib.rs"
 [dependencies]
 bitflags = "0.1"
 libc = "0.1"
-time = "0.1"
 lazy_static = "0.1"
 rustc-serialize = { optional = true, version = "0.3" }
 serde = { optional = true, version = "0.6" }

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,13 +1,10 @@
-extern crate time;
-
 use std::str;
 use std::ptr;
+use std::time::Duration;
 
 use std::ffi::{CStr, CString};
 use std::path::Path;
 use bindings::ffi;
-
-use self::time::Duration;
 
 pub fn set_fps(fps: i32) {
     assert!(fps >= 0);
@@ -31,8 +28,9 @@ pub fn get_last_frame_length() -> f32 {
 }
 
 pub fn sleep(time: Duration) {
+    let duration_ms = (time.as_secs() * 1000) as u32 + (time.subsec_nanos() / 1_000_000);
     unsafe {
-        ffi::TCOD_sys_sleep_milli(time.num_milliseconds() as u32);
+        ffi::TCOD_sys_sleep_milli(duration_ms);
     }
 }
 
@@ -40,7 +38,7 @@ pub fn get_elapsed_time() -> Duration {
     let ms: u32 = unsafe {
         ffi::TCOD_sys_elapsed_milli()
     };
-    Duration::milliseconds(ms as i64)
+    Duration::from_millis(ms as u64)
 }
 
 pub fn save_screenshot<P>(path: P) where P: AsRef<Path> {


### PR DESCRIPTION
`std::time::Duration` is stable as of Rust 1.3. Using it simplifies our
dependencies and should make interoperability with other code easier.

There is a couple of downsides:

First, the API of the Duration in std is smaller than the one in the
time crate so we need to e.g. do our own conversion to total seconds and
milliseconds elapsed. I'm hoping this will get better in the future or
will be something the time crate will adopt while using
std::time::Duration for the underlying data.

Second, this is a breaking change because it no longer works with the
older (<=1.2) compilers.