### PR TITLE
Small fixes

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -100,19 +100,19 @@ pub struct Key {
     pub ctrl: bool,
 }
 
-impl Into<Key> for ffi::TCOD_key_t {
-    fn into(self) -> Key {
+impl From<ffi::TCOD_key_t> for Key {
+    fn from(tcod_key: ffi::TCOD_key_t) -> Key {
         Key {
-            code: keycode_from_u32(self.vk).unwrap(),
-            printable: self.c as u8 as char,
-            pressed: self.pressed != 0,
-            left_alt: self.lalt != 0,
-            left_ctrl: self.lctrl != 0,
-            right_alt: self.ralt != 0,
-            right_ctrl: self.rctrl != 0,
-            shift: self.shift != 0,
-            alt: self.lalt != 0 || self.ralt != 0,
-            ctrl: self.lctrl != 0 || self.rctrl != 0,
+            code: keycode_from_u32(tcod_key.vk).unwrap(),
+            printable: tcod_key.c as u8 as char,
+            pressed: tcod_key.pressed != 0,
+            left_alt: tcod_key.lalt != 0,
+            left_ctrl: tcod_key.lctrl != 0,
+            right_alt: tcod_key.ralt != 0,
+            right_ctrl: tcod_key.rctrl != 0,
+            shift: tcod_key.shift != 0,
+            alt: tcod_key.lalt != 0 || tcod_key.ralt != 0,
+            ctrl: tcod_key.lctrl != 0 || tcod_key.rctrl != 0,
         }
     }
 }

--- a/src/namegen.rs
+++ b/src/namegen.rs
@@ -23,7 +23,7 @@ impl Drop for Namegen {
             let _lock = NAMEGEN_MUTEX.lock()
                 .ok()
                 .expect("Namegen mutex could not be locked");
-            if self.rng.len() > 0 {
+            if self.rng.is_empty() {
                 ffi::TCOD_namegen_destroy();
             }
             NAMEGEN_FREE = true;


### PR DESCRIPTION
Non-breaking change with small fixes: 

1. Use `is_empty` instead of `len() > 0`
2. Implement `From` instead of `Into` for `Key`. The reason: `Into` is blanket implemented for everything that implements `From`, so we get an extra trait for no cost.