### PR TITLE
Exclude zlib.a from the package

### DIFF
--- a/tcod_sys/Cargo.toml
+++ b/tcod_sys/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/tomassedovic/tcod-rs/tree/master/tcod-sys"
 authors = ["tomas@sedovic.cz"]
 links = "tcod"
 build = "build.rs"
+exclude = [
+    "libtcod/lib/libz.a"
+]
 
 [lib]
 name = "tcod_sys"


### PR DESCRIPTION
It should never have been included in the first place and Cargo seems to
be ignoring the .gitignore file.

Fixes #165.