### PR TITLE
Add a `make package` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,12 @@ build:
 
 test:
 	cargo test  --features "rustc-serialize_impls"
+
+package: clean
+	cargo package --manifest-path tcod_sys/Cargo.toml
+	cargo package
+
+clean:
+	git clean -x -f -d
+
+.PHONY: build test package clean


### PR DESCRIPTION
It will package both tcod and tcod_sys, making sure none of the
generated files (*.a, etc.) are included.