### PR TITLE
Fix for crater builds

### DIFF
--- a/tcod_sys/build.rs
+++ b/tcod_sys/build.rs
@@ -3,6 +3,12 @@ use std::path::Path;
 use std::process::Command;
 
 fn main() {
+    let is_crater = option_env!("CRATER_TASK_TYPE");
+
+    if is_crater.is_some() {
+        return;
+    }
+
     let src_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     let dst_dir = env::var("OUT_DIR").unwrap();
 


### PR DESCRIPTION
Here's a basic workaround for the crater builds. A few things:

- Should I check for every enviromental variable, or do you think think `CRATER_TASK_TYPE` is enough? 
- This has the annoying property that the user has to manually do a `cargo clean` betwen a crater and a non-crater build. I don't think this is too much of a downside, but I have no idea how to fix it

Closes #210