### PR TITLE
Make the AsciiLiteral trait public

### DIFF
--- a/src/console.rs
+++ b/src/console.rs
@@ -524,7 +524,7 @@ impl<'a> TcodString for &'a String {
     }
 }
 
-trait AsciiLiteral {}
+pub trait AsciiLiteral {}
 impl AsciiLiteral for [u8] {}
 
 // AsciiLiteral is implemented for fixed-size arrays up to length 32, same as the current


### PR DESCRIPTION
We're getting a warning for E0446 in the recent builds. Making this
trait public fixes it.