### PR TITLE
Update libc version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ path = "src/lib.rs"
 
 [dependencies]
 bitflags = "0.1"
-libc = "0.1"
+libc = "0.2"
 lazy_static = "0.1"
 rustc-serialize = { optional = true, version = "0.3" }
 serde = { optional = true, version = "0.6" }

--- a/tcod_sys/Cargo.toml
+++ b/tcod_sys/Cargo.toml
@@ -17,7 +17,7 @@ name = "tcod_sys"
 path = "lib.rs"
 
 [dependencies]
-libc = "0.1"
+libc = "0.2"
 
 [build-dependencies]
 gcc = "0.3"


### PR DESCRIPTION
Older versions of libc no longer compile on latest Rust (1.7 stable at
the moment)[1][2]. This updates our required dependency version to
0.1.12, but it seems that this alone will not rebuild Cargo.lock if it
has an incompatible libc.

Fixes #216

[1]: https://github.com/rust-lang-deprecated/time/issues/84
[2]: https://github.com/tomassedovic/tcod-rs/issues/216