### PR TITLE
Explicitly re-export tcod_sys (ffi)

### DIFF
--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1,5 +1,6 @@
+pub extern crate tcod_sys as ffi;
+
 extern crate libc;
-extern crate tcod_sys as ffi;
 
 pub use std::ffi::CString;
 pub use self::libc::{c_char, c_int, c_float, c_uint, c_void, uint8_t};


### PR DESCRIPTION
Exporting extern crates without marking them public will be phased out
in future versions of the compiler, see
https://github.com/rust-lang/rust/pull/31362

This was caught in a crater run by the core team here:
https://gist.github.com/alexcrichton/78cf7d4740391546e2d5