### PR TITLE
Remove the '.dll' suffix from windows-gnu target

### DIFF
--- a/tcod_sys/build.rs
+++ b/tcod_sys/build.rs
@@ -208,7 +208,7 @@ fn main() {
         compile_config(config);
         assert!(dst.join("libtcod.dll").is_file());
 
-        println!("cargo:rustc-link-lib=dylib={}", "SDL.dll");
+        println!("cargo:rustc-link-lib=dylib={}", "SDL");
         println!("cargo:rustc-link-lib=dylib={}", "opengl32");
         println!("cargo:rustc-link-search=native={}", sdl_lib_dir.display());
         println!("cargo:rustc-link-search=native={}", dst.display());


### PR DESCRIPTION
This should fix the issue #222 according to the following build run:

https://ci.appveyor.com/project/tomassedovic/tcod-window/build/1.0.5

Looks like MinGW expects to get just the dynamic library's name without
the suffix.