### PR TITLE
Add Console::get_default_background

### DIFF
--- a/src/console.rs
+++ b/src/console.rs
@@ -642,6 +642,15 @@ pub trait Console : AsNative<ffi::TCOD_console_t> {
         }
     }
 
+    /// Return the console's default background color. This is used in
+    /// several other methods, like: `clear`, `put_char`, etc.
+    fn get_default_background(&mut self) -> Color {
+        unsafe {
+            FromNative::from_native(
+                ffi::TCOD_console_get_default_background(*self.as_native()))
+        }
+    }
+
     /// Sets the console's default background color. This is used in several other methods,
     /// like: `clear`, `put_char`, etc.
     fn set_default_background(&mut self, color: Color) {


### PR DESCRIPTION
Useful counterpart to the `set_default_background` method.