### PR TITLE
Fix the with and height asserts in Console::rect

### DIFF
--- a/src/console.rs
+++ b/src/console.rs
@@ -894,8 +894,12 @@ pub trait Console : AsNative<ffi::TCOD_console_t> {
             width: i32, height: i32,
             clear: bool,
             background_flag: BackgroundFlag) {
-        assert!(x >= 0 && y >= 0 && width >= 0 && height >= 0);
-        assert!(x + width < self.width() && y + height < self.height());
+        assert!(x >= 0);
+        assert!(y >= 0);
+        assert!(width >= 0);
+        assert!(height >= 0);
+        assert!(x + width <= self.width());
+        assert!(y + height <= self.height());
         unsafe {
             ffi::TCOD_console_rect(*self.as_native(), x, y, width, height, clear as c_bool, background_flag as u32);
         }


### PR DESCRIPTION
The upstream docs are wrong on this one: `x + width` can be equal to the
console's width as well. It would be impossible to have a rect that ends
at the right edge of the console. And the same goes for height.

In addition, I've split the conditions each into its own assert. When it
fires, it's useful to know which condition in particular failed (was it
the `x` or the `y` check?). This generates much more useful error
messages.