### PR TITLE
Add pkg-config as an OSX prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ You can also check the [official libtcod build instructions for Windows](http://
 2. Run:
 
 ```sh
-$ brew install sdl
+$ brew install pkg-config sdl
 $ cd yourgame
 $ cargo build --release
 $ cargo run --release


### PR DESCRIPTION
As evidenced in issue #232, pkg-config might not be installed on a Mac,
but we need it for the tcod-sys build script.