### PR TITLE
examples: Remove usused `crate tcod_sys`

### DIFF
--- a/examples/samples.rs
+++ b/examples/samples.rs
@@ -1,5 +1,4 @@
 extern crate tcod;
-extern crate tcod_sys as ffi;
 extern crate rand;
 
 use tcod::console::*;


### PR DESCRIPTION
The example doesn't need direct access to this crate.