### PR TITLE
Build static library for libtcod on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,17 @@ on your distro.
 
 You can also check the [official libtcod build instructions for Linux](http://roguecentral.org/doryen/data/libtcod/doc/1.5.2/html2/compile_libtcod_linux.html?c=true).
 
+#### Building a dynamic library
+
+By default, `tcod-rs` will build the library statically on Linux as including
+the code into the executable is usually more convenient. To build a dynamic
+library specify the `dynlib` feature for `tcod_sys` in `Cargo.toml`
+
+```
+[dependencies.tcod_sys]
+version = "..."
+features = ["dynlib"]
+```
 
 ### Building on Windows (with MSVC)
 

--- a/tcod_sys/Cargo.toml
+++ b/tcod_sys/Cargo.toml
@@ -16,6 +16,9 @@ exclude = [
 name = "tcod_sys"
 path = "lib.rs"
 
+[features]
+dynlib = []
+
 [build-dependencies]
 cc = "1.0"
 pkg-config = "0.3"


### PR DESCRIPTION
Build static library for libtcod on Linux

Tell rust to link the static version of libtcod on Linux.
This avoids issues about where to put `libtcod.so` at run time by including the code in the executable itself.

This is my attempt at #262. I think the same should work for other operating systems but I am unable to test this right now.