### PR TITLE
Sync/Send for Map

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -1,6 +1,9 @@
 use bindings::ffi::{self, TCOD_fov_algorithm_t};
 use bindings::{AsNative, c_bool};
 
+unsafe impl Sync for Map {}
+unsafe impl Send for Map {}
+
 pub struct Map {
     tcod_map: ffi::TCOD_map_t,
 }

--- a/src/pathfinding.rs
+++ b/src/pathfinding.rs
@@ -63,7 +63,8 @@ impl<'a> AStar<'a> {
 
     pub fn new_from_map(map: Map, diagonal_cost: f32) -> AStar<'static> {
         let tcod_path = unsafe {
-            ffi::TCOD_path_new_using_map(*map.as_native(), diagonal_cost)
+            let tcod_map = *map.as_native().lock().unwrap();
+            ffi::TCOD_path_new_using_map(tcod_map, diagonal_cost)
         };
         let (w, h) = map.size();
         AStar {
@@ -207,7 +208,8 @@ impl<'a> Dijkstra<'a> {
 
     pub fn new_from_map(map: Map, diagonal_cost: f32) -> Dijkstra<'static> {
         let tcod_path = unsafe {
-            ffi::TCOD_dijkstra_new(*map.as_native(), diagonal_cost)
+            let tcod_map = *map.as_native().lock().unwrap();
+            ffi::TCOD_dijkstra_new(tcod_map, diagonal_cost)
         };
         let (w, h) = map.size();
         Dijkstra {


### PR DESCRIPTION
I needed this change so that I could add `Map` as a `Write<'a Map>` resource using specs (https://github.com/slide-rs/specs). It's been working great and I have not witnessed any sort of issues. Is there any reason this couldn't be merged?

Thanks!