### PR TITLE
README.md: mention that version 1.6.3 is wrapped

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ useful functionality such as:
 
 
 This project provides [Rust](http://www.rust-lang.org/) bindings for libtcod
-v1.5.2.
+v1.6.3.
 
 This project follows [Semantic Versioning](http://semver.org/). Since we're
 under `1.0.0` anything goes. The API can change at any time.


### PR DESCRIPTION
This was updated in #256, since then https://github.com/tomassedovic/tcod-rs/blob/master/tcod_sys/libtcod/README.md mentions 1.6.3, however the README.md incorrectly still mentioned 1.5.2.
(the project description on github also does)