### PR TITLE
Fix SDL2 rendering in Mojave

### DIFF
--- a/tcod_sys/libtcod/src/sys_sdl2_c.c
+++ b/tcod_sys/libtcod/src/sys_sdl2_c.c
@@ -289,6 +289,8 @@ static void create_window(int w, int h, bool fullscreen) {
 #endif		
 		if (TCOD_ctx.renderer == TCOD_RENDERER_SDL ) {
 			window = SDL_CreateWindow(TCOD_ctx.window_title,SDL_WINDOWPOS_CENTERED,SDL_WINDOWPOS_CENTERED,w*TCOD_ctx.font_width,h*TCOD_ctx.font_height,winflags);
+			SDL_PumpEvents();
+			SDL_SetWindowSize(window,w*TCOD_ctx.font_width,h*TCOD_ctx.font_height);
 			TCOD_LOG(("Using SDL renderer...\n"));
 		}
 		if ( window == NULL ) TCOD_fatal_nopar("SDL : cannot create window");


### PR DESCRIPTION
Related to https://github.com/tomassedovic/tcod-rs/issues/267

Basically, SDL2 on OS X requires you to `SDL_PumpEvents()` before setting the window size, otherwise you get a blank screen until it receives an event, such as a keyboard event or window resize event.

See also: https://discourse.libsdl.org/t/macos-10-14-mojave-issues/25060