### PR TITLE
Added Send to Offscreen

### DIFF
--- a/src/console.rs
+++ b/src/console.rs
@@ -128,6 +128,10 @@ impl Offscreen {
 
 }
 
+// ! libtcod is not thread-safe, this may have some side effects but none have been seen yet
+// ! This is primary so that Offscreen consoles can be used as specs resources
+unsafe impl Send for Offscreen {}
+
 /// The console representing the main window of the application
 ///
 /// This is the only console type capable of handling user input and flushing its contents onto the screen.


### PR DESCRIPTION
Marked Offscreen as Send, this is probably not actually safe because libtcod is not threadsafe, but so far I've not found any problems.  In the meantime this would allow Offscreen consoles to be used as resources in specs (like the Root console).