### PR TITLE
Update the CI whitelist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,10 @@ rust:
 - stable
 matrix:
   allow_failures:
+  - os: linux
+    rust: nightly
   - os: osx
-    rust: stable
+    rust: nightly
 before_install:
 - '[ "$TRAVIS_OS_NAME" = linux ] && sudo apt-get update -qq || brew update'
 install:


### PR DESCRIPTION
Stable is always required to pass, nightly is optional on both Linux
and macOS.