### PR TITLE
Add 'impl Clone' for Map using libtcod ffi function

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -76,6 +76,19 @@ impl Map {
     }
 }
 
+impl Clone for Map {
+    fn clone(&self) -> Self {
+        let (width, height) = self.size();
+        let new_map = Map::new(width, height);
+
+        unsafe {
+            ffi::TCOD_map_copy(*self.as_native(), *new_map.as_native());
+        }
+
+        new_map
+    }
+}
+
 impl Drop for Map {
     fn drop(&mut self) {
         unsafe {


### PR DESCRIPTION
This change adds an implementation of Clone for the Map type using the TCOD_map_copy function from tcod.

This addresses issue #284 