### PR TITLE
Added Send to Map

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -84,6 +84,10 @@ impl Drop for Map {
     }
 }
 
+// ! libtcod is not thread-safe, this may have some side effects but none have been seen yet
+// ! This is primary so that Map can be used as specs resources
+unsafe impl Send for Map {}
+
 #[repr(u32)]
 #[derive(Copy, Clone, Debug)]
 pub enum FovAlgorithm {


### PR DESCRIPTION
In the vein of #274, this is basically a lighter version of #265 until #259 is "properly" resolved. (User code will still need to `Arc<Mutex<Map>>`, which I think is an OK trade-off at this point)

Use-case: using Specs, I want to be a good little boy-scout, and have a dedicated `FovSystem` update a `Map` resource that is then read by the `RenderSystem`.