### PR TITLE
Fix documentation of building tcod-sys as dynamic lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,11 @@ on your distro.
 
 By default, `tcod-rs` will build the library statically on Linux as including
 the code into the executable is usually more convenient. To build a dynamic
-library specify the `dynlib` feature for `tcod_sys` in `Cargo.toml`
+library specify the `dynlib` feature for `tcod-sys` in `Cargo.toml`
 
 ```
-[dependencies.tcod_sys]
-version = "..."
+[dependencies.tcod-sys]
+version = "*"
 features = ["dynlib"]
 ```
 


### PR DESCRIPTION
realized the README is wrong about the crate-name while investigating the recent build failures.

it should now be copy-and-pasteable and just work