### PR TITLE
Fix build on linux

### DIFF
--- a/tcod_sys/build.rs
+++ b/tcod_sys/build.rs
@@ -312,4 +312,5 @@ fn main() {
 
     println!("cargo:rustc-link-search={}", dst.display());
     println!("cargo:rustc-link-lib=dylib=tcod");
+    println!("cargo:rustc-link-lib=SDL2");
 }


### PR DESCRIPTION
The recent build failures seem to have been introduced in rust 1.35, because the compiler handles redundant linker flags differently.
It is now important to have the last occurrence of `-lSDL2` after the last occurrence of `-ltcod`

i am not sure if this is the right fix, but it seems to get everything going again and should resolve #288