### PR TITLE
fix bare trait object warnings on rust-nightly

### DIFF
--- a/examples/blit.rs
+++ b/examples/blit.rs
@@ -13,8 +13,8 @@ fn main() {
 
     let mut direct: OffscreenConsole = OffscreenConsole::new(20, 20);
     let mut boxed_direct: Box<OffscreenConsole> = Box::new(OffscreenConsole::new(20, 20));
-    let mut trait_object: &Console = &OffscreenConsole::new(20, 20);
-    let mut boxed_trait: Box<Console> = Box::new(OffscreenConsole::new(20, 20));
+    let mut trait_object: &dyn Console = &OffscreenConsole::new(20, 20);
+    let mut boxed_trait: Box<dyn Console> = Box::new(OffscreenConsole::new(20, 20));
 
 
     root.set_default_background(colors::DARKEST_GREEN);

--- a/examples/samples.rs
+++ b/examples/samples.rs
@@ -92,7 +92,7 @@ impl ColorsSample {
 
     }
 
-    fn set_colors(&self, console: &mut Console) {
+    fn set_colors(&self, console: &mut dyn Console) {
         enum Dir {
             TopLeft = 0,
             TopRight,
@@ -121,7 +121,7 @@ impl ColorsSample {
         }
     }
 
-    fn print_random_chars(&mut self, console: &mut Console) -> colors::Color {
+    fn print_random_chars(&mut self, console: &mut dyn Console) -> colors::Color {
         // ==== print the text with a random color ====
         // get the background color at the text position
         let mut text_color = console.get_char_background(SAMPLE_SCREEN_WIDTH/2, 5);
@@ -1519,11 +1519,11 @@ impl Render for NameSample {
 
 struct MenuItem<'a> {
     name: String,
-    render: &'a mut Render
+    render: &'a mut dyn Render
 }
 
 impl<'a> MenuItem<'a> {
-    fn new(name: &str, render: &'a mut Render) -> Self {
+    fn new(name: &str, render: &'a mut dyn Render) -> Self {
         MenuItem { name: name.to_owned(), render: render }
     }
 }

--- a/src/bsp.rs
+++ b/src/bsp.rs
@@ -220,7 +220,7 @@ impl<'a> Bsp<'a> {
     pub fn traverse<F>(&self, order: TraverseOrder, mut callback: F) -> bool
         where F: FnMut(&mut Bsp) -> bool
     {
-        let cb: &mut FnMut(&mut Bsp) -> bool = &mut callback;
+        let cb: &mut dyn FnMut(&mut Bsp) -> bool = &mut callback;
         let retval = unsafe {
             let bsp = mem::transmute(self.bsp as *const ffi::TCOD_bsp_t);
             match order {

--- a/src/console.rs
+++ b/src/console.rs
@@ -461,9 +461,9 @@ impl Root {
 pub struct RootInitializer<'a> {
     width: i32,
     height: i32,
-    title: Box<AsRef<str> + 'a>,
+    title: Box<dyn AsRef<str> + 'a>,
     is_fullscreen: bool,
-    font_path: Box<AsRef<Path> + 'a>,
+    font_path: Box<dyn AsRef<Path> + 'a>,
     font_layout: FontLayout,
     font_type: FontType,
     font_dimensions: (i32, i32),

--- a/src/pathfinding.rs
+++ b/src/pathfinding.rs
@@ -4,7 +4,7 @@ use map::Map;
 
 enum PathInnerData<'a> {
     Map(Map),
-    Callback(Box<FnMut((i32, i32), (i32, i32)) -> f32+'a>),
+    Callback(Box<dyn FnMut((i32, i32), (i32, i32)) -> f32+'a>),
 }
 
 pub struct AStar<'a>{


### PR DESCRIPTION
the new `dyn` syntax for trait-objects is available since rust 1.27
rust-nightly has started warning that the old syntax is deprecated.

https://doc.rust-lang.org/edition-guide/rust-2018/trait-system/dyn-trait-for-trait-objects.html