### PR TITLE
Fix libtcod link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 libtcod bindings for Rust [![Build Status](https://travis-ci.org/tomassedovic/tcod-rs.svg?branch=master)](https://travis-ci.org/tomassedovic/tcod-rs)
 -------------------------
 
-[libtcod a.k.a. "The Doryen Library"](https://bitbucket.org/libtcod/libtcod)
+[libtcod a.k.a. "The Doryen Library"](https://github.com/libtcod/libtcod)
 is a smallish library designed for writing roguelikes. It provides a bunch of
 useful functionality such as:
 


### PR DESCRIPTION
The project has moved to github in the meantime, fix this.