### PR TITLE
Protect against segfault and clean up warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ path = "src/lib.rs"
 
 [dependencies]
 bitflags = "0.1"
-lazy_static = "0.1"
+lazy_static = "1.4"
 rustc-serialize = { optional = true, version = "0.3" }
 serde = { optional = true, version = "1.0" }
 serde_derive = { optional = true, version = "1.0" }

--- a/examples/samples.rs
+++ b/examples/samples.rs
@@ -546,7 +546,7 @@ impl Render for NoiseSample {
 
         if let Some((_, Event::Key(key))) = event {
             match key.printable {
-                '1'...'9' =>
+                '1'..='9' =>
                     self.func = {
                         let number = key.printable.to_digit(10).unwrap() as u8;
                         NoiseFunction::from_value(number - 1)
@@ -778,7 +778,7 @@ struct PathSample<'a> {
 }
 
 const TORCH_RADIUS : f32 = 10.0;
-const SQUARED_TORCH_RADIUS : f32 = (TORCH_RADIUS*TORCH_RADIUS);
+const SQUARED_TORCH_RADIUS : f32 = TORCH_RADIUS*TORCH_RADIUS;
 
 static SMAP : [&'static str; 20] = [
     "##############################################",

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -40,7 +40,7 @@ impl <T, U: AsNative<T> + ?Sized> AsNative<T> for Box<U> {
 
 pub fn keycode_from_native(input: self::ffi::TCOD_keycode_t) -> Option<KeyCode> {
     match input as u32 {
-        x @ 0 ... 66 => Some(unsafe { transmute(x) }),
+        x @ 0 ..= 66 => Some(unsafe { transmute(x) }),
         _ => None
     }
 }

--- a/src/pathfinding.rs
+++ b/src/pathfinding.rs
@@ -148,7 +148,7 @@ impl<'a> AStar<'a> {
             let mut x: c_int = 0;
             let mut y: c_int = 0;
             ffi::TCOD_path_get(self.tcod_path, index, &mut x, &mut y);
-            (Some((x, y)))
+            Some((x, y))
         }
     }
 

--- a/src/pathfinding.rs
+++ b/src/pathfinding.rs
@@ -278,8 +278,10 @@ impl<'a> Dijkstra<'a> {
     }
 
     pub fn reverse(&mut self) {
-        unsafe {
-            ffi::TCOD_dijkstra_reverse(self.tcod_path);
+        if !self.is_empty() {
+            unsafe {
+                ffi::TCOD_dijkstra_reverse(self.tcod_path);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #310 - Segfault appears to be in the TCOD library, it can't handle reversing an empty list in the Dijkstra example finding a path from (0, 0) to (0, 0). Added a protective check around the call the the underlying library. The A* implementation works differently enough to be unaffected from what I can see.

Fixes #297 - `...` ranges replaced with `..=` and unneeded brackets removed. Also updated lazy_static to latest version which resolves a deprecation warning generated from a macro in there.

I'll leave this open for a week or so before merging to give chance for comments, none of this seems urgent until the deprecations become breaking.